### PR TITLE
[#3] Rest Docs Asciidoc 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '17'
 
 configurations {
+	asciidoctorExtensions
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
@@ -43,6 +44,7 @@ dependencies {
 
 	// rest docs
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+	asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 
 	// valid
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -55,5 +57,20 @@ tasks.named('test') {
 
 tasks.named('asciidoctor') {
 	inputs.dir snippetsDir
+	configurations 'asciidoctorExtensions'
 	dependsOn test
+}
+
+asciidoctor.doFirst {
+	delete file('src/main/resources/static/docs')
+}
+
+task copyDocument(type: Copy) {
+	dependsOn asciidoctor
+	from file("build/docs/asciidoc")
+	into file("src/main/resources/static/docs")
+}
+
+build {
+	dependsOn copyDocument
 }

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -1,0 +1,12 @@
+= Hyper Link
+backtony.github.io(Rest Docs)
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs // 문서에 표기되는 코드들의 하이라이팅을 highlightjs를 사용
+:toc: left
+:toclevels: 4
+:sectlinks:
+
+== Member
+=== 회원가입
+operation::test/testk[snippets='http-request,http-response,response-fields']


### PR DESCRIPTION
- 적용 방법
1. Controller 테스트 작성
2. Controller 테스트 돌리기
3. /build/generated-snippets 경로로 들어가면 Controller 테스트에 해당하는 adoc 파일이 생성된 것을 확인할 수 있어요
4. /src/docs/asciidoc/api.adoc 파일 내에 API에 해당하는 명세 작성 (adoc 파일 추가)

api.adoc 파일에 예시로 테스트 api 명세를 추가해놓았어요
추후에 삭제할 예정이에요!

close #3 