### PR TITLE
[#4] jacoco report, coverage 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'org.springframework.boot' version '2.7.8'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 	id 'org.asciidoctor.jvm.convert' version '3.3.2'
+	id 'jacoco'
 }
 
 group = 'com.hyper-link'
@@ -22,6 +23,11 @@ repositories {
 
 ext {
 	set('snippetsDir', file("build/generated-snippets"))
+}
+
+jacoco {
+	toolVersion = '0.8.8'
+	file("$buildDir/customJacocoReportDir")
 }
 
 dependencies {
@@ -53,6 +59,7 @@ dependencies {
 tasks.named('test') {
 	outputs.dir snippetsDir
 	useJUnitPlatform()
+	finalizedBy 'jacocoTestReport'
 }
 
 tasks.named('asciidoctor') {
@@ -73,4 +80,29 @@ task copyDocument(type: Copy) {
 
 build {
 	dependsOn copyDocument
+}
+
+jacocoTestReport {
+	reports {
+		xml.enabled false
+		csv.enabled false
+		html.destination file("${buildDir}/jacocoHtml")
+	}
+
+	finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+	violationRules {
+		rule {
+			enabled = true
+			element = 'CLASS'
+
+			limit {
+				counter = 'LINE'
+				value = 'COVEREDRATIO'
+				minimum = 0.80
+			}
+		}
+	}
 }


### PR DESCRIPTION
### 변경 내용 요약
- jacoco report, coverage 설정

### 작업한 내용
- 전체 test 실행 후 build/jacocoHtml 경로에 들어가시면 jacoco가 생성해준 report(html 파일)를 확인하실 수 있어요 (커버리지 수치, 내용)
- 80% 미달 시 빌드 실패하도록 설정했어요
  - 현재는 작성한 테스트 코드가 전혀 없기 때문에 CI에서 빌드 실패가 발생될 것 같아요 (커버리지 80% 미달)
  - 어느 정도 개발이 진행되기 전까지는 감수해야할 것 같아요!
  - 이번주 내로 개발 진행하면서 80%까지 끌어올려야 할 것 같습니다

close #4 
