### PR TITLE
[#15] Production 환경에 대한 CI/CD 구축

### DIFF
--- a/.github/workflows/ci-prod.yml
+++ b/.github/workflows/ci-prod.yml
@@ -44,7 +44,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: 빌드
-        run: SPRING_PROFILES_ACTIVE=[set1] ./gradlew clean build -x test asciidoctor
+        run: SPRING_PROFILES_ACTIVE=[set1] ./gradlew clean build -x test -x :asciidoctor
 
       - name: aws 세팅
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/ci-prod.yml
+++ b/.github/workflows/ci-prod.yml
@@ -44,7 +44,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: 빌드
-        run: SPRING_PROFILES_ACTIVE=[set1] ./gradlew clean build -x test -x :asciidoctor
+        run: SPRING_PROFILES_ACTIVE=[set1] ./gradlew clean build -x test
 
       - name: aws 세팅
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/ci-prod.yml
+++ b/.github/workflows/ci-prod.yml
@@ -44,7 +44,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: 빌드
-        run: SPRING_PROFILES_ACTIVE=[set1] ./gradlew clean build -x test
+        run: SPRING_PROFILES_ACTIVE=[set1] ./gradlew clean build -x test asciidoctor
 
       - name: aws 세팅
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/ci-prod.yml
+++ b/.github/workflows/ci-prod.yml
@@ -1,0 +1,69 @@
+# This is a basic workflow to help you get started with Actions
+name: hyperlink-production CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the dev branch
+on:
+  push:
+    branches: main
+  pull_request:
+    branches: main
+
+env:
+  DEPLOY_ZIP_FILE: hyperlink-prod-deploy.zip
+  S3_DEPLOY_BUCKET: hyperlink-prod-deploy
+  DEPLOY_GROUP_NAME: hyperlink-prod-deploy-group
+  DEPLOY_APPLICATION_NAME: hyperlink-deploy
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+
+      - name: JDK 17 설치
+        uses: actions/setup-java@v1
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: application-prod.yml 생성
+        run: |
+          touch src/main/resources/application.yml
+
+      - name: application.yml 설정
+        run: echo "${{secrets.APPLICATIONPRODUCTION}}" > src/main/resources/application.yml
+
+      - name: ./gradlew 권한 설정
+        run: chmod +x ./gradlew
+
+      - name: 빌드
+        run: SPRING_PROFILES_ACTIVE=[set1] ./gradlew clean build -x test
+
+      - name: aws 세팅
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      - name: Zip 파일 생성
+        run: |
+          mkdir -p before-deploy/
+          cp appspec.yml before-deploy/
+          cp scripts/*.sh before-deploy/
+          cp build/libs/*.jar before-deploy/
+          cd before-deploy && zip -r before-deploy *
+          cd ../ && mkdir -p deploy
+          mv before-deploy/before-deploy.zip deploy/$DEPLOY_ZIP_FILE
+      - name: S3 업로드
+        run: aws s3 cp --region ap-northeast-2 ./deploy/$DEPLOY_ZIP_FILE s3://$S3_DEPLOY_BUCKET/server/build.zip
+
+      - name: code deploy
+        run: aws deploy create-deployment --application-name $DEPLOY_APPLICATION_NAME --deployment-config-name CodeDeployDefault.OneAtATime --deployment-group-name $DEPLOY_GROUP_NAME --s3-location bucket=$S3_DEPLOY_BUCKET,bundleType=zip,key=server/build.zip

--- a/.github/workflows/ci-prod.yml
+++ b/.github/workflows/ci-prod.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           touch src/main/resources/application.yml
 
-      - name: application.yml 설정
+      - name: application-prod.yml 설정
         run: echo "${{secrets.APPLICATIONPRODUCTION}}" > src/main/resources/application.yml
 
       - name: ./gradlew 권한 설정

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -9,4 +9,4 @@ backtony.github.io(Rest Docs)
 
 == Member
 === 회원가입
-// operation::test/testk[snippets='http-request,http-response,response-fields']
+operation::test/testk[snippets='http-request,http-response,response-fields']

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -9,4 +9,4 @@ backtony.github.io(Rest Docs)
 
 == Member
 === 회원가입
-operation::test/testk[snippets='http-request,http-response,response-fields']
+// operation::test/testk[snippets='http-request,http-response,response-fields']


### PR DESCRIPTION

### 변경 내용 요약
- 기존 Develop 환경에서와 비슷하게 Production 환경에 대한 블루/그린 무중단 배포를 구성했습니다.
- Production 환경에는 main 브랜치에 push, pr 시에만 CI/CD되며, CI의 경우 이미 develop 브랜치를 거쳐야 main 브랜치로 넘어가도록 하기 때문에 빌드 테스트는 진행하지 않습니다.(테스트 코드에서 더미 데이터를 실제 production DB에 저장하는 불상사를 막기 위한 목적도 있습니다.)

### 작업한 내용
- 기존 develop 환경에 대한 CD는 그대로 유지했습니다.
- CI의 경우에만 다른 S3 버킷, 다른 Code Deploy 그룹, 등의 차이가 있어서 ci-prod.yml 파일을 만들었습니다.
- main 브랜치에 Push, PR될 경우에만 동작합니다.
- 내부적으로는 application-prod.yml이 아닌 application.yml로 사용하게 했으며 application-prod.yml은 깃허브의 secret key로 두어 사용했습니다.

### 기타사항
- CI / CD 적용기 글을 작성할 예정입니다. 궁금하신 점이 있다면 해당 문서를 참고해주셔도 좋을 것 같습니다!

close #15 
