### PR TITLE
[#22] 테스트 커버리지 측정 기준 변경 및 엔티티 오류 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,14 @@ jacocoTestReport {
 		html.destination file("${buildDir}/jacocoHtml")
 	}
 
+	afterEvaluate {
+		classDirectories.setFrom(files(classDirectories.files.collect {
+			fileTree(dir: it, exclude: [
+					"com/hyperlink/server/ServerApplication.*",
+			])
+		}))
+	}
+
 	finalizedBy 'jacocoTestCoverageVerification'
 }
 

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/src/main/java/com/hyperlink/server/domain/member/MemberService.java
+++ b/src/main/java/com/hyperlink/server/domain/member/MemberService.java
@@ -1,5 +1,0 @@
-package com.hyperlink.server.domain.member;
-
-public class MemberService {
-
-}

--- a/src/main/java/com/hyperlink/server/domain/memberContent/domain/entity/MemberContent.java
+++ b/src/main/java/com/hyperlink/server/domain/memberContent/domain/entity/MemberContent.java
@@ -23,7 +23,16 @@ public class MemberContent extends BaseEntity {
   @Column(columnDefinition = "INT UNSIGNED", nullable = false)
   private Integer type;
 
-  public MemberContent(MemberContentActionType type) {
-    this.type = type.getType();
+  @Column
+  private Long memberId;
+
+  @Column
+  private Long contentId;
+
+
+  public MemberContent(Long memberId, Long contentId, MemberContentActionType type) {
+    this.memberId = memberId;
+    this.contentId = contentId;
+    this.type = type.getTypeNumber();
   }
 }

--- a/src/main/java/com/hyperlink/server/domain/memberContent/domain/entity/MemberContentActionType.java
+++ b/src/main/java/com/hyperlink/server/domain/memberContent/domain/entity/MemberContentActionType.java
@@ -5,11 +5,11 @@ import lombok.Getter;
 @Getter
 public enum MemberContentActionType {
 
-  LIKE(1), SUBSCRIPTION(2);
+  LIKE(1), BOOKMARK(2);
 
-  final int type;
+  final int typeNumber;
 
-  MemberContentActionType(int type) {
-    this.type = type;
+  MemberContentActionType(int typeNumber) {
+    this.typeNumber = typeNumber;
   }
 }


### PR DESCRIPTION
### 변경 내용 요약
- 테스트 커버리지 측정 기준 변경
- 엔티티 맵핑 오류 수정

### 작업한 내용
- Getter와 같이 lombok 어노테이션 코드로 자동으로 만들어지는 코드는 커버리지 측정 기준에서 제외시켰어요.
  - 테스트가 어려운 클래스이거나, 불필요하다고 생각되는 클래스는 직접 제외시켜주셔야 80% 기준에 맞출 수 있을 것 같아요
  - 가령 현재 존재하는 ProfileController 클래스의 경우에도 테스트가 없기 때문에 커버리지를 낮추는 원인으로 동작하고 있는데, 테스트 코드를 만들어주시거나 테스트가 어렵다고 판단되면 build.gradle 파일을 통해 제외시켜주셔야 해요

### 기타사항
- MemberContent 엔티티의 경우 제가 올린 저번 PR에서 연관관계 맵핑이 전혀 되지 않았는데 아무도 리뷰를 안 해주셨더라구요..
여러분.. 저희팀 함께 하고 있는거 맞죠..?🥹 다행히 스스로 발견해서 수정해 올립니다 😅
- 해당 PR은 머지 먼저 하겠습니다! 코드는 꼭 봐주세요! 😊
- 해당 PR 머지 후 내용 반영된 main 브랜치 기반으로 develop 브랜치 새로 생성할 예정입니다!

close #22
