### PR TITLE
[#35] DB 컬럼 추가 및 컬럼 속성 추가

### DIFF
--- a/src/main/java/com/hyperlink/server/domain/content/domain/entity/Content.java
+++ b/src/main/java/com/hyperlink/server/domain/content/domain/entity/Content.java
@@ -9,6 +9,7 @@ import javax.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter
@@ -28,4 +29,8 @@ public class Content extends BaseEntity {
 
   @Column(nullable = false)
   private String link;
+
+  @Column(columnDefinition = "INT UNSIGNED", nullable = false)
+  @ColumnDefault("0")
+  private int inquiry = 0;
 }

--- a/src/main/resources/db/migration/V4__add_column_inqu.sql
+++ b/src/main/resources/db/migration/V4__add_column_inqu.sql
@@ -1,0 +1,2 @@
+alter table `content`
+    add `inquiry` int unsigned not null default 0 after `link`;

--- a/src/main/resources/db/migration/V5__datetime_auto.sql
+++ b/src/main/resources/db/migration/V5__datetime_auto.sql
@@ -1,0 +1,49 @@
+alter table category
+    modify created_at datetime default CURRENT_TIMESTAMP;
+alter table category
+    modify updated_at datetime default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP;
+
+alter table attention_category
+    modify created_at datetime default CURRENT_TIMESTAMP;
+alter table attention_category
+    modify updated_at datetime default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP;
+
+alter table company
+    modify created_at datetime default CURRENT_TIMESTAMP;
+alter table company
+    modify updated_at datetime default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP;
+
+alter table content
+    modify created_at datetime default CURRENT_TIMESTAMP;
+alter table content
+    modify updated_at datetime default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP;
+
+alter table content_category
+    modify created_at datetime default CURRENT_TIMESTAMP;
+alter table content_category
+    modify updated_at datetime default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP;
+
+alter table creator
+    modify created_at datetime default CURRENT_TIMESTAMP;
+alter table creator
+    modify updated_at datetime default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP;
+
+alter table creator_category
+    modify created_at datetime default CURRENT_TIMESTAMP;
+alter table creator_category
+    modify updated_at datetime default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP;
+
+alter table member
+    modify created_at datetime default CURRENT_TIMESTAMP;
+alter table member
+    modify updated_at datetime default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP;
+
+alter table member_content
+    modify created_at datetime default CURRENT_TIMESTAMP;
+alter table member_content
+    modify updated_at datetime default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP;
+
+alter table subscription
+    modify created_at datetime default CURRENT_TIMESTAMP;
+alter table subscription
+    modify updated_at datetime default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP;


### PR DESCRIPTION
### 변경 내용 요약
- content table 조회수 컬럼 추가
- 모든 table created_at, updated_at 자동 업데이트 추가

### 작업한 내용
- content table에 조회수 관련된 컬럼이 없어서 추가했어요
- created_at, updated_at 컬럼의 자동 업데이트 설정을 추가했어요

close #35
