### PR TITLE
[#38] jacoco 테스트 빌드 대상 항목 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,7 @@ jacocoTestReport {
 		classDirectories.setFrom(files(classDirectories.files.collect {
 			fileTree(dir: it, exclude: [
 					"com/hyperlink/server/ServerApplication.*",
+					"com/hyperlink/server/global/profile/controller/ProfileController.*"
 			])
 		}))
 	}

--- a/src/main/java/com/hyperlink/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/hyperlink/server/global/exception/GlobalExceptionHandler.java
@@ -47,12 +47,6 @@ public class GlobalExceptionHandler {
     return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).body(errorResponse);
   }
 
-  @ExceptionHandler(MaxUploadSizeExceededException.class)
-  public ResponseEntity<ErrorResponse> handleFileSizeLimitedMethod() {
-    ErrorResponse errorResponse = new ErrorResponse("허용가능한 파일 사이즈를 초과하였습니다.");
-    return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE).body(errorResponse);
-  }
-
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ErrorResponse> handleUnexpectedException(final Exception e,
       final HttpServletRequest request) {


### PR DESCRIPTION
### 변경 내용 요약
- jacoco 테스트 커버리지 측정 대상 클래스를 수정하고 사용하지 않는 GlobalExceptionHandler 메서드를 제거

### 작업한 내용
- Method : handleUnexpectedException -> jacoco 커버리지 측정 제외는 실패함 -> 클래스, 패키지 단위로만 제외 가능
- Method : handleFileSizeLimitedMethod() -> 코드 내 삭제
- Class : ProfileController -> jacoco 커버리지 측정 제외

### 기타사항


close #38 
