### PR TITLE
[#28] 블로그 글 크롤링 기능 구현

### DIFF
--- a/src/main/resources/crawling-scripts/develop/crawling-d2-develop.js
+++ b/src/main/resources/crawling-scripts/develop/crawling-d2-develop.js
@@ -1,0 +1,30 @@
+const axios = require('axios');
+const cheerio = require('cheerio');
+
+async function main() {
+    const response = await axios.get(
+       "https://d2.naver.com/api/v1/contents?categoryId=&page=0&size=30"
+    );
+    // response.data => json data
+    const elements = response.data.content;
+
+
+    resultList = []
+    elements.forEach((elem) => {
+        if(elem.postPublishedAt < Date.parse("2022-01-01")) return false;
+        console.log((new Date(elem.postPublishedAt).toDateString()));
+        resultList.push({
+            title: elem.postTitle,
+            link: "https://d2.naver.com" +  elem.url,
+            contentImgLink: 
+                elem.postImage != undefined ? 
+                "https://d2.naver.com" + elem.postImage : 
+                "https://hyperlink-data.s3.ap-northeast-2.amazonaws.com/content-default-image/logo_naver_d2.jpg",
+            category: "develop",
+            creator: "네이버 D2 기술 블로그"
+        })
+    });
+    return resultList;
+}
+main()
+.then(response => console.log(response));

--- a/src/main/resources/crawling-scripts/develop/crawling-daangn-develop.js
+++ b/src/main/resources/crawling-scripts/develop/crawling-daangn-develop.js
@@ -1,0 +1,48 @@
+const axios = require('axios');
+const cheerio = require('cheerio');
+
+async function getHTML(year, month) {
+    if(month < 10) {
+        month = '0' + month;
+    }
+    try {
+        console.log("https://medium.com/daangn/archive/" + year + "/" + month);
+        let config = {
+            headers: {
+                Accept: "text/html"
+            }
+        }
+        return await axios.get("https://medium.com/daangn/archive/" + year + "/" + month, config);
+    } catch(err) {
+        console.log(err);
+    }
+}
+
+async function main() {
+    resultList = []
+    for(let year = 2022; year <= 2023; year++) {
+        for(let month = 1; month <= 12; month++) {
+            if(year == 2023 && month >= 3) break;
+            const response = await getHTML(year, month);
+            const $ = cheerio.load(response.data);
+            // response ==> html
+            const elements = $("div.js-postStream").children("div.streamItem");
+            elements.each((idx, elem) => {
+                resultList.push({
+                    title: $(elem).find("h3.graf--title").text(),
+                    link: $(elem).find("div.postArticle").find("div:nth-child(3) a").attr("href"),
+                    contentImgLink: 
+                    $(elem).find(".postArticle-content.js-postField").find(".section-content").find(".section-inner.sectionLayout--insetColumn").find("#previewImage").find(".graf-image").attr("src") != undefined ? 
+                    $(elem).find(".postArticle-content.js-postField").find(".section-content").find(".section-inner.sectionLayout--insetColumn").find("#previewImage").find(".graf-image").attr("src") : 
+                        "https://hyperlink-data.s3.ap-northeast-2.amazonaws.com/content-default-image/logo_daangn.png",
+                    category: "develop",
+                    creator: "당근마켓 기술 블로그"
+                })
+            });
+        }
+    }
+    
+    return resultList;
+}
+main()
+.then(response => console.log(response));

--- a/src/main/resources/crawling-scripts/develop/crawling-kakao-develop.js
+++ b/src/main/resources/crawling-scripts/develop/crawling-kakao-develop.js
@@ -1,0 +1,32 @@
+const axios = require('axios');
+const cheerio = require('cheerio');
+
+async function main() {
+    resultList = []
+    for(let pageNum = 1; pageNum <= 11; pageNum++) {
+        const response = await axios.get(
+            'https://tech.kakao.com/blog/page/'+ pageNum + '/#posts'
+        );
+    
+        const $ = cheerio.load(response.data);
+        const elements = $('.elementor-posts-container.elementor-posts.elementor-posts--skin-classic.elementor-grid').children(".elementor-post");
+    
+        
+        elements.each((idx, elem) => {
+            if(Date.parse($(elem).find(".elementor-post__text .elementor-post-date").text()) < Date.parse("2022-01-01")) return false;
+    
+            resultList.push({
+                title:$(elem).find(".elementor-post__text .elementor-post__title a").text().trim(),
+                link: $(elem).find(".elementor-post__text .elementor-post__title a").attr("href"),
+                contentImgLink: "https://hyperlink-data.s3.ap-northeast-2.amazonaws.com/content-default-image/logo-kakao-tech.png",
+                category: "develop",
+                creator: "카카오 기술 블로그"
+            })
+            console.log("date : " + $(elem).find(".elementor-post__text .elementor-post-date").text());
+        });
+    }
+    
+    return resultList;
+}
+main()
+.then(response => console.log(response));

--- a/src/main/resources/crawling-scripts/develop/crawling-kurly-develop.js
+++ b/src/main/resources/crawling-scripts/develop/crawling-kurly-develop.js
@@ -1,0 +1,30 @@
+const axios = require('axios');
+const cheerio = require('cheerio');
+
+async function main() {
+    const response = await axios.get(
+        'https://helloworld.kurly.com/'
+    );
+
+    const $ = cheerio.load(response.data);
+    const elements = $('ul.post-list').children("li.post-card");
+
+    resultList = []
+    elements.each((idx, elem) => {
+        if(Date.parse($(elem).find("span.post-meta").find("span.post-date").text()) < Date.parse("2022-01-01")) return false;
+        console.log(new Date(Date.parse($(elem).find("span.post-meta").find("span.post-date").text())).toDateString());
+        resultList.push({
+            title: $(elem).find("h3.post-title").text(),
+            link: "https://helloworld.kurly.com" +  $(elem).find("a.post-link").attr("href"),
+            contentImgLink: 
+                $(elem).find("span.post-thumb").attr("style") != undefined  ? 
+                "https://helloworld.kurly.com" + $(elem).find("span.post-thumb").attr("style").split('\'')[1] : 
+                "https://hyperlink-data.s3.ap-northeast-2.amazonaws.com/content-default-image/logo_sns_marketkurly.jpg",
+            category: "develop",
+            creator: "컬리 기술 블로그"
+        })
+    });
+    return resultList;
+}
+main()
+.then(response => console.log(response));

--- a/src/main/resources/crawling-scripts/develop/crawling-toss-develop.js
+++ b/src/main/resources/crawling-scripts/develop/crawling-toss-develop.js
@@ -1,0 +1,30 @@
+const axios = require('axios');
+const cheerio = require('cheerio');
+
+async function main() {
+    const response = await axios.get(
+        'https://toss.tech/tech'
+    );
+
+    const $ = cheerio.load(response.data);
+    const elements = $('ul.css-onwccc').children("a");
+
+    resultList = []
+    elements.each((idx, elem) => {
+        if(Date.parse($(elem).find("span.e3wfjt70").text()) < Date.parse("2022-01-01")) return false;
+        console.log(new Date(Date.parse($(elem).find("span.e3wfjt70").text())).toDateString());
+        resultList.push({
+            title: $(elem).find("span.e3wfjt74").text(),
+            link: 'https://toss.tech/tech' +  $(elem).attr("href"),
+            contentImgLink: 
+                $(elem).find("img").attr("srcset") != undefined  ? 
+                $(elem).find("img").attr("srcset").split(' ')[0] : 
+                "https://hyperlink-data.s3.ap-northeast-2.amazonaws.com/content-default-image/logo_toss.png",
+            category: "develop",
+            creator: "토스 기술 블로그"
+        })
+    });
+    return resultList;
+}
+main()
+.then(response => console.log(response));

--- a/src/main/resources/crawling-scripts/fashion/crawling-vogue-beauty.js
+++ b/src/main/resources/crawling-scripts/fashion/crawling-vogue-beauty.js
@@ -1,0 +1,34 @@
+const axios = require('axios');
+const cheerio = require('cheerio');
+
+async function main() {
+    resultList = []
+    for(let pageNum = 1; pageNum <= 10; pageNum++) {
+        const response = await axios.get(
+            'https://www.vogue.co.kr/category/beauty/page/' + pageNum
+        );
+    
+        const $ = cheerio.load(response.data);
+        const elements = $('.fusion-posts-container.fusion-blog-layout-grid.fusion-blog-layout-grid-3.isotope.fusion-blog-layout-masonry.fusion-posts-container-infinite').children(".fusion-post-masonry.fusion-post-grid.fusion-element-portrait.post.fusion-clearfix.type-post");
+    
+        elements.each((idx, elem) => {
+            // if(Date.parse($(elem).find("span.post-meta").find("span.post-date").text()) < Date.parse("2022-01-01")) return false;
+            // console.log($(elem).find("span.post-thumb").attr("style")== undefined);
+            // console.log(new Date(Date.parse($(elem).find("span.post-meta").find("span.post-date").text())).toDateString());
+            resultList.push({
+                title: $(elem).find(".fusion-post-content-wrapper").find(".entry-title a").text(),
+                link: $(elem).find(".fusion-post-content-wrapper").find(".entry-title a").attr("href"),
+                contentImgLink: 
+                    $(elem).find(".fusion-masonry-element-container.fusion-image-wrapper a img").attr("src") != undefined  ? 
+                    $(elem).find(".fusion-masonry-element-container.fusion-image-wrapper a img").attr("src") : 
+                    "https://hyperlink-data.s3.ap-northeast-2.amazonaws.com/content-default-image/logo_vogue.png",
+                category: "fashion",
+                creator: "VOGUE 패션 매거진"
+            })
+        });
+    }
+    
+    return resultList;
+}
+main()
+.then(response => console.log(response));

--- a/src/main/resources/crawling-scripts/fashion/crawling-vogue-fashion.js
+++ b/src/main/resources/crawling-scripts/fashion/crawling-vogue-fashion.js
@@ -1,0 +1,34 @@
+const axios = require('axios');
+const cheerio = require('cheerio');
+
+async function main() {
+    resultList = []
+    for(let pageNum = 1; pageNum <= 10; pageNum++) {
+        const response = await axios.get(
+            'https://www.vogue.co.kr/category/fashion/page/' + pageNum
+        );
+    
+        const $ = cheerio.load(response.data);
+        const elements = $('.fusion-posts-container.fusion-blog-layout-grid.fusion-blog-layout-grid-3.isotope.fusion-blog-layout-masonry.fusion-posts-container-infinite').children(".fusion-post-masonry.fusion-post-grid.fusion-element-portrait.post.fusion-clearfix.type-post");
+    
+        elements.each((idx, elem) => {
+            // if(Date.parse($(elem).find("span.post-meta").find("span.post-date").text()) < Date.parse("2022-01-01")) return false;
+            // console.log($(elem).find("span.post-thumb").attr("style")== undefined);
+            // console.log(new Date(Date.parse($(elem).find("span.post-meta").find("span.post-date").text())).toDateString());
+            resultList.push({
+                title: $(elem).find(".fusion-post-content-wrapper").find(".entry-title a").text(),
+                link: $(elem).find(".fusion-post-content-wrapper").find(".entry-title a").attr("href"),
+                contentImgLink: 
+                    $(elem).find(".fusion-masonry-element-container.fusion-image-wrapper a img").attr("src") != undefined  ? 
+                    $(elem).find(".fusion-masonry-element-container.fusion-image-wrapper a img").attr("src") : 
+                    "https://hyperlink-data.s3.ap-northeast-2.amazonaws.com/content-default-image/logo_vogue.png",
+                category: "fashion",
+                creator: "VOGUE 패션 매거진"
+            })
+        });
+    }
+    
+    return resultList;
+}
+main()
+.then(response => console.log(response));


### PR DESCRIPTION
### 변경 내용 요약
- 개발, 패션 블로그 크롤링 기능 추가

### 작업한 내용
- 개발 블로그 크롤링(2022.01 이후의 데이터 크롤링함)
  - 대상 기업
    - 네이버
    - 카카오
    - 당근마켓
    - 마켓컬리
    - 토스
- 패션 블로그 or 매거진 크롤링(데이터의 양이 많아 최신 120개의 데이터 크롤링함)
  - 대상 매거진
    - VOGUE 패션 매거진
    - VOGUE 뷰티 매거진

### 기타사항
- 현재 데이터를 DB에 저장하는 단계는 아니므로 DB에서 확인할 수 없는 점 유의바랍니다.
- 다음 이슈 PR에서 DB에 저장하도록 진행하겠습니다.
- js 스크립트 코드는 리뷰 목적으로만 존재하며 실제 서비스 단계에서는 동작하지 않는 것이 정상입니다. 다른 인스턴스에서 크롤링 작업을 진행할 것입니다.

close #28 
