### PR TITLE
[#66] Creator 생성 로직 구현

### DIFF
--- a/src/main/java/com/hyperlink/server/domain/category/domain/CategoryRepository.java
+++ b/src/main/java/com/hyperlink/server/domain/category/domain/CategoryRepository.java
@@ -1,8 +1,9 @@
 package com.hyperlink.server.domain.category.domain;
 
 import com.hyperlink.server.domain.category.domain.entity.Category;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
-
+  Optional<Category> findByName(String name);
 }

--- a/src/main/java/com/hyperlink/server/domain/category/domain/entity/Category.java
+++ b/src/main/java/com/hyperlink/server/domain/category/domain/entity/Category.java
@@ -22,4 +22,8 @@ public class Category extends BaseEntity {
 
   @Column(length = 30, nullable = false)
   private String name;
+
+  public Category(String name) {
+    this.name = name;
+  }
 }

--- a/src/main/java/com/hyperlink/server/domain/category/exception/CategoryNotFoundException.java
+++ b/src/main/java/com/hyperlink/server/domain/category/exception/CategoryNotFoundException.java
@@ -1,0 +1,14 @@
+package com.hyperlink.server.domain.category.exception;
+
+import com.hyperlink.server.global.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class CategoryNotFoundException extends BusinessException {
+
+  private static final String MESSAGE = "카테고리를 찾을 수 없습니다.";
+  private static final HttpStatus status = HttpStatus.NOT_FOUND;
+
+  public CategoryNotFoundException() {
+    super(MESSAGE, status);
+  }
+}

--- a/src/main/java/com/hyperlink/server/domain/creator/application/CreatorService.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/application/CreatorService.java
@@ -1,0 +1,29 @@
+package com.hyperlink.server.domain.creator.application;
+
+import com.hyperlink.server.domain.category.domain.CategoryRepository;
+import com.hyperlink.server.domain.category.domain.entity.Category;
+import com.hyperlink.server.domain.category.exception.CategoryNotFoundException;
+import com.hyperlink.server.domain.creator.domain.CreatorRepository;
+import com.hyperlink.server.domain.creator.domain.entity.Creator;
+import com.hyperlink.server.domain.creator.dto.CreatorEnrollRequest;
+import com.hyperlink.server.domain.creator.dto.CreatorEnrollResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CreatorService {
+
+  private final CreatorRepository creatorRepository;
+  private final CategoryRepository categoryRepository;
+
+  @Transactional
+  public CreatorEnrollResponse enrollCreator(CreatorEnrollRequest creatorEnrollRequest) {
+    Category category = categoryRepository.findByName(creatorEnrollRequest.categoryName())
+        .orElseThrow(CategoryNotFoundException::new);
+    Creator creator = CreatorEnrollRequest.toCreator(creatorEnrollRequest, category);
+    Creator savedCreator = creatorRepository.save(creator);
+    return CreatorEnrollResponse.from(savedCreator);
+  }
+}

--- a/src/main/java/com/hyperlink/server/domain/creator/controller/CreatorController.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/controller/CreatorController.java
@@ -1,0 +1,26 @@
+package com.hyperlink.server.domain.creator.controller;
+
+import com.hyperlink.server.domain.creator.application.CreatorService;
+import com.hyperlink.server.domain.creator.dto.CreatorEnrollRequest;
+import com.hyperlink.server.domain.creator.dto.CreatorEnrollResponse;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class CreatorController {
+
+  private final CreatorService creatorService;
+
+  @PostMapping("/admin/creators")
+  @ResponseStatus(HttpStatus.CREATED)
+  public CreatorEnrollResponse enrollCreator(
+      @RequestBody @Valid CreatorEnrollRequest creatorEnrollRequest) {
+    return creatorService.enrollCreator(creatorEnrollRequest);
+  }
+}

--- a/src/main/java/com/hyperlink/server/domain/creator/domain/entity/Creator.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/domain/entity/Creator.java
@@ -37,4 +37,14 @@ public class Creator extends BaseEntity {
   @ManyToOne(fetch = FetchType.LAZY)
   private Category category;
 
+  public String getCategoryName() {
+    return category.getName();
+  }
+
+  public Creator(String name, String profileImgUrl, String description, Category category) {
+    this.name = name;
+    this.profileImgUrl = profileImgUrl;
+    this.description = description;
+    this.category = category;
+  }
 }

--- a/src/main/java/com/hyperlink/server/domain/creator/dto/CreatorEnrollRequest.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/dto/CreatorEnrollRequest.java
@@ -1,0 +1,16 @@
+package com.hyperlink.server.domain.creator.dto;
+
+import com.hyperlink.server.domain.category.domain.entity.Category;
+import com.hyperlink.server.domain.creator.domain.entity.Creator;
+import javax.validation.constraints.NotBlank;
+
+public record CreatorEnrollRequest(
+    @NotBlank String name,
+    String profileImgUrl,
+    @NotBlank String description,
+    @NotBlank String categoryName) {
+  public static Creator toCreator(CreatorEnrollRequest creatorEnrollRequest, Category category) {
+    return new Creator(creatorEnrollRequest.name(), creatorEnrollRequest.profileImgUrl(),
+        creatorEnrollRequest.description(), category);
+  }
+}

--- a/src/main/java/com/hyperlink/server/domain/creator/dto/CreatorEnrollResponse.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/dto/CreatorEnrollResponse.java
@@ -1,0 +1,11 @@
+package com.hyperlink.server.domain.creator.dto;
+
+import com.hyperlink.server.domain.creator.domain.entity.Creator;
+
+public record CreatorEnrollResponse(Long id, String name, String profileImgUrl, String description,
+                                    String categoryName) {
+  public static CreatorEnrollResponse from(Creator creator) {
+    return new CreatorEnrollResponse(creator.getId(), creator.getName(), creator.getProfileImgUrl(),
+        creator.getDescription(), creator.getCategoryName());
+  }
+}

--- a/src/test/java/com/hyperlink/server/category/domain/CategoryRepositoryTest.java
+++ b/src/test/java/com/hyperlink/server/category/domain/CategoryRepositoryTest.java
@@ -1,0 +1,32 @@
+package com.hyperlink.server.category.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hyperlink.server.domain.category.domain.CategoryRepository;
+import com.hyperlink.server.domain.category.domain.entity.Category;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+public class CategoryRepositoryTest {
+
+  @Autowired
+  CategoryRepository categoryRepository;
+
+  @Test
+  @DisplayName("카테고리를 이름으로 검색할 수 있다.")
+  void find_category_by_name() {
+    Category developCategory = new Category("develop");
+    categoryRepository.save(developCategory);
+
+    Optional<Category> categoryOptional = categoryRepository.findByName(developCategory.getName());
+    assertThat(categoryOptional).isPresent();
+    assertThat(categoryOptional.get().getName()).isEqualTo(developCategory.getName());
+  }
+}

--- a/src/test/java/com/hyperlink/server/creator/application/CreatorServiceIntegrationTest.java
+++ b/src/test/java/com/hyperlink/server/creator/application/CreatorServiceIntegrationTest.java
@@ -35,17 +35,15 @@ public class CreatorServiceIntegrationTest {
 
   @Nested
   @DisplayName("크리에이터 생성 메서드는")
-  class CreatorConstructTest {
+  class CreatorEnrollTest {
 
     @Test
     @DisplayName("성공하면 크리에이터로 등록된다.")
     public void success() throws Exception {
-      //given
       Category develop = new Category("develop");
       CreatorEnrollRequest creatorEnrollRequest = new CreatorEnrollRequest("크리에이터 이름",
           "profileImgUrl", "크리에이터입니다.", "develop");
 
-      // when
       categoryRepository.save(develop);
       CreatorEnrollResponse creatorEnrollResponse = creatorService.enrollCreator(creatorEnrollRequest);
       //then
@@ -57,7 +55,6 @@ public class CreatorServiceIntegrationTest {
     @Test
     @DisplayName("없는 카테고리 이름으로 등록하면 CategoryNotFoundException이 발생한다.")
     public void fail() throws Exception {
-      //given
       CreatorEnrollRequest creatorEnrollRequest = new CreatorEnrollRequest("크리에이터 이름",
           "profileImgUrl", "크리에이터입니다.", "develop");
 

--- a/src/test/java/com/hyperlink/server/creator/application/CreatorServiceIntegrationTest.java
+++ b/src/test/java/com/hyperlink/server/creator/application/CreatorServiceIntegrationTest.java
@@ -1,0 +1,70 @@
+package com.hyperlink.server.creator.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.hyperlink.server.domain.category.domain.CategoryRepository;
+import com.hyperlink.server.domain.category.domain.entity.Category;
+import com.hyperlink.server.domain.category.exception.CategoryNotFoundException;
+import com.hyperlink.server.domain.creator.application.CreatorService;
+import com.hyperlink.server.domain.creator.domain.CreatorRepository;
+import com.hyperlink.server.domain.creator.domain.entity.Creator;
+import com.hyperlink.server.domain.creator.dto.CreatorEnrollRequest;
+import com.hyperlink.server.domain.creator.dto.CreatorEnrollResponse;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@DisplayName("CreatorService 통합 테스트")
+public class CreatorServiceIntegrationTest {
+
+  @Autowired
+  CreatorService creatorService;
+
+  @Autowired
+  CategoryRepository categoryRepository;
+
+  @Autowired
+  CreatorRepository creatorRepository;
+
+  @Nested
+  @DisplayName("크리에이터 생성 메서드는")
+  class CreatorConstructTest {
+
+    @Test
+    @DisplayName("성공하면 크리에이터로 등록된다.")
+    public void success() throws Exception {
+      //given
+      Category develop = new Category("develop");
+      CreatorEnrollRequest creatorEnrollRequest = new CreatorEnrollRequest("크리에이터 이름",
+          "profileImgUrl", "크리에이터입니다.", "develop");
+
+      // when
+      categoryRepository.save(develop);
+      CreatorEnrollResponse creatorEnrollResponse = creatorService.enrollCreator(creatorEnrollRequest);
+      //then
+      Optional<Creator> foundCreator = creatorRepository.findById(creatorEnrollResponse.id());
+      assertThat(foundCreator).isPresent();
+      assertThat(foundCreator.get().getName()).isEqualTo(creatorEnrollRequest.name());
+    }
+
+    @Test
+    @DisplayName("없는 카테고리 이름으로 등록하면 CategoryNotFoundException이 발생한다.")
+    public void fail() throws Exception {
+      //given
+      CreatorEnrollRequest creatorEnrollRequest = new CreatorEnrollRequest("크리에이터 이름",
+          "profileImgUrl", "크리에이터입니다.", "develop");
+
+      assertThatThrownBy(() -> creatorService.enrollCreator(creatorEnrollRequest))
+          .isInstanceOf(CategoryNotFoundException.class);
+    }
+  }
+
+
+}

--- a/src/test/java/com/hyperlink/server/creator/application/CreatorServiceMockTest.java
+++ b/src/test/java/com/hyperlink/server/creator/application/CreatorServiceMockTest.java
@@ -34,17 +34,16 @@ public class CreatorServiceMockTest {
 
   @Nested
   @DisplayName("크리에이터 생성 메서드는")
-  class CreatorConstructTest {
+  class CreatorEnrollTest {
 
     @Test
     @DisplayName("성공하면 크리에이터를 생성한다.")
     public void success() throws Exception {
-      //given
       Category developCategory = new Category("develop");
       CreatorEnrollRequest creatorEnrollRequest = new CreatorEnrollRequest("크리에이터 이름",
           "profileImgUrl", "크리에이터입니다.", "develop");
       Creator creator = CreatorEnrollRequest.toCreator(creatorEnrollRequest, developCategory);
-      // when
+
       when(categoryRepository.findByName(developCategory.getName())).thenReturn(
           Optional.of(developCategory));
       when(creatorRepository.save(any()))
@@ -54,7 +53,7 @@ public class CreatorServiceMockTest {
       CreatorEnrollResponse creatorEnrollResponse = creatorService.enrollCreator(
           creatorEnrollRequest);
 
-      //then
+
       Assertions.assertNotNull(creatorEnrollResponse);
     }
 

--- a/src/test/java/com/hyperlink/server/creator/application/CreatorServiceMockTest.java
+++ b/src/test/java/com/hyperlink/server/creator/application/CreatorServiceMockTest.java
@@ -1,0 +1,78 @@
+package com.hyperlink.server.creator.application;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.hyperlink.server.domain.category.domain.CategoryRepository;
+import com.hyperlink.server.domain.category.domain.entity.Category;
+import com.hyperlink.server.domain.category.exception.CategoryNotFoundException;
+import com.hyperlink.server.domain.creator.application.CreatorService;
+import com.hyperlink.server.domain.creator.domain.CreatorRepository;
+import com.hyperlink.server.domain.creator.domain.entity.Creator;
+import com.hyperlink.server.domain.creator.dto.CreatorEnrollRequest;
+import com.hyperlink.server.domain.creator.dto.CreatorEnrollResponse;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CreatorService Mock 테스트")
+public class CreatorServiceMockTest {
+
+  @Mock
+  CategoryRepository categoryRepository;
+
+  @Mock
+  CreatorRepository creatorRepository;
+
+  @Nested
+  @DisplayName("크리에이터 생성 메서드는")
+  class CreatorConstructTest {
+
+    @Test
+    @DisplayName("성공하면 크리에이터를 생성한다.")
+    public void success() throws Exception {
+      //given
+      Category developCategory = new Category("develop");
+      CreatorEnrollRequest creatorEnrollRequest = new CreatorEnrollRequest("크리에이터 이름",
+          "profileImgUrl", "크리에이터입니다.", "develop");
+      Creator creator = CreatorEnrollRequest.toCreator(creatorEnrollRequest, developCategory);
+      // when
+      when(categoryRepository.findByName(developCategory.getName())).thenReturn(
+          Optional.of(developCategory));
+      when(creatorRepository.save(any()))
+          .thenReturn(new Creator("크리에이터 이름",
+              "profileImgUrl", "크리에이터입니다.", developCategory));
+      CreatorService creatorService = new CreatorService(creatorRepository, categoryRepository);
+      CreatorEnrollResponse creatorEnrollResponse = creatorService.enrollCreator(
+          creatorEnrollRequest);
+
+      //then
+      Assertions.assertNotNull(creatorEnrollResponse);
+    }
+
+    @Test
+    @DisplayName("저장하려고하는 크리에이터의 카테고리가 없으면 CategoryNotFoundException이 발생한다.")
+    public void fail() throws Exception {
+      //given
+      CreatorEnrollRequest creatorEnrollRequest = new CreatorEnrollRequest("크리에이터 이름",
+          "profileImgUrl", "크리에이터입니다.", "emptyCategory");
+      // when
+      when(categoryRepository.findByName(any())).thenThrow(new CategoryNotFoundException());
+      CreatorService creatorService = new CreatorService(creatorRepository, categoryRepository);
+
+      //then
+      Assertions.assertThrows(CategoryNotFoundException.class, () -> {
+        creatorService.enrollCreator(creatorEnrollRequest);
+      });
+    }
+  }
+
+}

--- a/src/test/java/com/hyperlink/server/creator/controller/CreatorControllerTest.java
+++ b/src/test/java/com/hyperlink/server/creator/controller/CreatorControllerTest.java
@@ -37,7 +37,7 @@ public class CreatorControllerTest {
 
   @Nested
   @DisplayName("크리에이터 생성 API는")
-  class EnrollCreatorTest {
+  class CreatorEnrollTest {
 
 
     @Nested
@@ -47,10 +47,10 @@ public class CreatorControllerTest {
       @Test
       @DisplayName("크리에이터 이름이 누락되면 BadRequest를 응답한다.")
       public void blankInName() throws Exception {
-        //given
+
         CreatorEnrollRequest creatorEnrollRequest = new CreatorEnrollRequest("", "profileImgUrl",
             "description", "categoryName");
-        // when & then
+
         mockMvc.perform(
                 post("/admin/creators")
                     .content(objectMapper.writeValueAsString(creatorEnrollRequest))
@@ -63,11 +63,11 @@ public class CreatorControllerTest {
       @Test
       @DisplayName("크리에이터 설명글(description)이 누락되면 BadRequest를 응답한다.")
       public void blankInDescription() throws Exception {
-        //given
+
         CreatorEnrollRequest creatorEnrollRequest = new CreatorEnrollRequest("creatorName",
             "profileImgUrl",
             "", "categoryName");
-        // when & then
+
         mockMvc.perform(
                 post("/admin/creators")
                     .content(objectMapper.writeValueAsString(creatorEnrollRequest))
@@ -80,11 +80,11 @@ public class CreatorControllerTest {
       @Test
       @DisplayName("크리에이터 카테고리 이름이 누락되면 BadRequest를 응답한다.")
       public void blankInCategoryName() throws Exception {
-        //given
+
         CreatorEnrollRequest creatorEnrollRequest = new CreatorEnrollRequest("creatorName",
             "profileImgUrl",
             "description", "");
-        // when & then
+
         mockMvc.perform(
                 post("/admin/creators")
                     .content(objectMapper.writeValueAsString(creatorEnrollRequest))
@@ -102,13 +102,13 @@ public class CreatorControllerTest {
       @Test
       @DisplayName("모든 요청 값이 올바르면 Created를 응답하고 CreatorEnrollResponse를 반환한다.")
       public void enrollCreatorStatusCreatedReturnCreatorEnrollResponse() throws Exception {
-        //given
+
         CreatorEnrollRequest creatorEnrollRequest = new CreatorEnrollRequest("creatorName",
             "profileImgUrl", "description", "categoryName");
         given(creatorService.enrollCreator(creatorEnrollRequest)).willReturn(
             new CreatorEnrollResponse(1L, "creatorName", "profileImgUrl", "description",
                 "categoryName"));
-        // when & then
+
         mockMvc.perform(
                 post("/admin/creators")
                     .content(objectMapper.writeValueAsString(creatorEnrollRequest))

--- a/src/test/java/com/hyperlink/server/creator/controller/CreatorControllerTest.java
+++ b/src/test/java/com/hyperlink/server/creator/controller/CreatorControllerTest.java
@@ -1,0 +1,121 @@
+package com.hyperlink.server.creator.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hyperlink.server.domain.creator.application.CreatorService;
+import com.hyperlink.server.domain.creator.controller.CreatorController;
+import com.hyperlink.server.domain.creator.dto.CreatorEnrollRequest;
+import com.hyperlink.server.domain.creator.dto.CreatorEnrollResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+@WebMvcTest(CreatorController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+public class CreatorControllerTest {
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @MockBean
+  CreatorService creatorService;
+
+  @Nested
+  @DisplayName("크리에이터 생성 API는")
+  class EnrollCreatorTest {
+
+
+    @Nested
+    @DisplayName("[실패] 크리에이터 생성 요청 중")
+    class Fail {
+
+      @Test
+      @DisplayName("크리에이터 이름이 누락되면 BadRequest를 응답한다.")
+      public void blankInName() throws Exception {
+        //given
+        CreatorEnrollRequest creatorEnrollRequest = new CreatorEnrollRequest("", "profileImgUrl",
+            "description", "categoryName");
+        // when & then
+        mockMvc.perform(
+                post("/admin/creators")
+                    .content(objectMapper.writeValueAsString(creatorEnrollRequest))
+                    .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest())
+            .andExpect(response -> Assertions.assertTrue(
+                response.getResolvedException() instanceof MethodArgumentNotValidException));
+      }
+
+      @Test
+      @DisplayName("크리에이터 설명글(description)이 누락되면 BadRequest를 응답한다.")
+      public void blankInDescription() throws Exception {
+        //given
+        CreatorEnrollRequest creatorEnrollRequest = new CreatorEnrollRequest("creatorName",
+            "profileImgUrl",
+            "", "categoryName");
+        // when & then
+        mockMvc.perform(
+                post("/admin/creators")
+                    .content(objectMapper.writeValueAsString(creatorEnrollRequest))
+                    .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest())
+            .andExpect(response -> Assertions.assertTrue(
+                response.getResolvedException() instanceof MethodArgumentNotValidException));
+      }
+
+      @Test
+      @DisplayName("크리에이터 카테고리 이름이 누락되면 BadRequest를 응답한다.")
+      public void blankInCategoryName() throws Exception {
+        //given
+        CreatorEnrollRequest creatorEnrollRequest = new CreatorEnrollRequest("creatorName",
+            "profileImgUrl",
+            "description", "");
+        // when & then
+        mockMvc.perform(
+                post("/admin/creators")
+                    .content(objectMapper.writeValueAsString(creatorEnrollRequest))
+                    .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest())
+            .andExpect(response -> Assertions.assertTrue(
+                response.getResolvedException() instanceof MethodArgumentNotValidException));
+      }
+    }
+
+    @Nested
+    @DisplayName("[성공] 크리에이터 생성 요청 중")
+    class Success {
+
+      @Test
+      @DisplayName("모든 요청 값이 올바르면 Created를 응답하고 CreatorEnrollResponse를 반환한다.")
+      public void enrollCreatorStatusCreatedReturnCreatorEnrollResponse() throws Exception {
+        //given
+        CreatorEnrollRequest creatorEnrollRequest = new CreatorEnrollRequest("creatorName",
+            "profileImgUrl", "description", "categoryName");
+        given(creatorService.enrollCreator(creatorEnrollRequest)).willReturn(
+            new CreatorEnrollResponse(1L, "creatorName", "profileImgUrl", "description",
+                "categoryName"));
+        // when & then
+        mockMvc.perform(
+                post("/admin/creators")
+                    .content(objectMapper.writeValueAsString(creatorEnrollRequest))
+                    .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isCreated())
+            .andDo(print());
+      }
+    }
+  }
+}


### PR DESCRIPTION
### 변경 내용 요약
- 크리에이터 생성 로직 구현

### 작업한 내용
- 크리에이터 생성 로직 구현
- 크리에이터 생성 로직 테스트 코드 작성

### 기타사항
- 커밋 메시지에도 적혀있지만, Admin 페이지에서만 크리에이터를 생성할 수 있도록 관리할 예정이에요.
- 이를 위해서, Member 도메인에서 해당 사용자가 관리자인지 아닌지 확인하는 로직이 필요할 것 같아요.
- 수요일 스크럼 시간에 이야기해보면 좋겠습니다.
@kivv00ng @yeeeze 

close #66 
