### PR TITLE
[#57] 크롤링 데이터 DB 업로드 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,9 @@ dependencies {
 
     // apache kafka
     implementation 'org.springframework.kafka:spring-kafka'
+
+	// amqp
+	implementation 'org.springframework.boot:spring-boot-starter-amqp'
 }
 
 def querydslDir = "$buildDir/generated/querydsl"

--- a/src/main/java/com/hyperlink/server/domain/content/application/ContentService.java
+++ b/src/main/java/com/hyperlink/server/domain/content/application/ContentService.java
@@ -5,6 +5,7 @@ import com.hyperlink.server.domain.content.domain.entity.Content;
 import com.hyperlink.server.domain.content.dto.ContentResponse;
 import com.hyperlink.server.domain.content.dto.RecommendationCompanyResponse;
 import com.hyperlink.server.domain.content.dto.SearchResponse;
+import com.hyperlink.server.domain.content.dto.ContentCreationResponse;
 import com.hyperlink.server.domain.content.exception.ContentNotFoundException;
 import com.hyperlink.server.domain.content.infrastructure.ContentRepositoryCustom;
 import com.hyperlink.server.domain.memberContent.application.MemberContentService;
@@ -68,4 +69,9 @@ public class ContentService {
     return Arrays.asList(keyword.split(" "));
   }
 
+
+  @Transactional
+  public void insertContent(ContentCreationResponse contentCreationResponse) {
+
+  }
 }

--- a/src/main/java/com/hyperlink/server/domain/content/application/ContentService.java
+++ b/src/main/java/com/hyperlink/server/domain/content/application/ContentService.java
@@ -1,13 +1,19 @@
 package com.hyperlink.server.domain.content.application;
 
+import com.hyperlink.server.domain.category.domain.CategoryRepository;
+import com.hyperlink.server.domain.category.domain.entity.Category;
+import com.hyperlink.server.domain.category.exception.CategoryNotFoundException;
 import com.hyperlink.server.domain.content.domain.ContentRepository;
 import com.hyperlink.server.domain.content.domain.entity.Content;
+import com.hyperlink.server.domain.content.dto.ContentEnrollResponse;
 import com.hyperlink.server.domain.content.dto.ContentResponse;
 import com.hyperlink.server.domain.content.dto.RecommendationCompanyResponse;
 import com.hyperlink.server.domain.content.dto.SearchResponse;
-import com.hyperlink.server.domain.content.dto.ContentCreationResponse;
 import com.hyperlink.server.domain.content.exception.ContentNotFoundException;
 import com.hyperlink.server.domain.content.infrastructure.ContentRepositoryCustom;
+import com.hyperlink.server.domain.creator.domain.CreatorRepository;
+import com.hyperlink.server.domain.creator.domain.entity.Creator;
+import com.hyperlink.server.domain.creator.exception.CreatorNotFoundException;
 import com.hyperlink.server.domain.memberContent.application.MemberContentService;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -20,9 +26,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ContentService {
 
   private final ContentRepository contentRepository;
+  private final CategoryRepository categoryRepository;
+  private final CreatorRepository creatorRepository;
   private final ContentRepositoryCustom contentRepositoryCustom;
   private final MemberContentService memberContentService;
 
@@ -71,7 +80,16 @@ public class ContentService {
 
 
   @Transactional
-  public void insertContent(ContentCreationResponse contentCreationResponse) {
+  public Long insertContent(ContentEnrollResponse contentEnrollResponse) {
+    System.out.println(contentEnrollResponse);
 
+    Creator creator = creatorRepository.findByName(contentEnrollResponse.creator())
+        .orElseThrow(CreatorNotFoundException::new);
+    Category category = categoryRepository.findByName(contentEnrollResponse.category())
+        .orElseThrow(CategoryNotFoundException::new);
+
+    Content content = ContentEnrollResponse.toContent(contentEnrollResponse, creator, category);
+    contentRepository.save(content);
+    return content.getId();
   }
 }

--- a/src/main/java/com/hyperlink/server/domain/content/application/ContentService.java
+++ b/src/main/java/com/hyperlink/server/domain/content/application/ContentService.java
@@ -19,11 +19,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -81,14 +83,17 @@ public class ContentService {
 
   @Transactional
   public Long insertContent(ContentEnrollResponse contentEnrollResponse) {
-    System.out.println(contentEnrollResponse);
-
-    Creator creator = creatorRepository.findByName(contentEnrollResponse.creator())
+    Creator creator = creatorRepository.findByName(contentEnrollResponse.creatorName())
         .orElseThrow(CreatorNotFoundException::new);
-    Category category = categoryRepository.findByName(contentEnrollResponse.category())
+    Category category = categoryRepository.findByName(contentEnrollResponse.categoryName())
         .orElseThrow(CategoryNotFoundException::new);
 
     Content content = ContentEnrollResponse.toContent(contentEnrollResponse, creator, category);
+    boolean exist = contentRepository.existsByLink(content.getLink());
+    if(exist) {
+      log.info("이미 존재하는 컨텐츠입니다. {}", contentEnrollResponse);
+      return -1L;
+    }
     contentRepository.save(content);
     return content.getId();
   }

--- a/src/main/java/com/hyperlink/server/domain/content/controller/ContentConsumer.java
+++ b/src/main/java/com/hyperlink/server/domain/content/controller/ContentConsumer.java
@@ -2,20 +2,26 @@ package com.hyperlink.server.domain.content.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.hyperlink.server.domain.content.dto.ContentCreationResponse;
+import com.hyperlink.server.domain.content.application.ContentService;
+import com.hyperlink.server.domain.content.dto.ContentEnrollResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ContentConsumer {
 
   private final ObjectMapper objectMapper;
+  private final ContentService contentService;
 
-  @RabbitListener(queues="crawling-test-queue")
+  @RabbitListener(queues = "${spring.rabbitmq.listener.name}")
   public void handler(String message) throws JsonProcessingException {
-    ContentCreationResponse post = objectMapper.readValue(message, ContentCreationResponse.class);
-
+    ContentEnrollResponse contentEnrollResponse = objectMapper.readValue(message,
+        ContentEnrollResponse.class);
+    contentService.insertContent(contentEnrollResponse);
+    log.info("GET MESSAGE FROM RABBIT MQ! data : {}", contentEnrollResponse);
   }
 }

--- a/src/main/java/com/hyperlink/server/domain/content/controller/ContentConsumer.java
+++ b/src/main/java/com/hyperlink/server/domain/content/controller/ContentConsumer.java
@@ -1,0 +1,21 @@
+package com.hyperlink.server.domain.content.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hyperlink.server.domain.content.dto.ContentCreationResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ContentConsumer {
+
+  private final ObjectMapper objectMapper;
+
+  @RabbitListener(queues="crawling-test-queue")
+  public void handler(String message) throws JsonProcessingException {
+    ContentCreationResponse post = objectMapper.readValue(message, ContentCreationResponse.class);
+
+  }
+}

--- a/src/main/java/com/hyperlink/server/domain/content/domain/ContentRepository.java
+++ b/src/main/java/com/hyperlink/server/domain/content/domain/ContentRepository.java
@@ -14,4 +14,6 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
   void updateViewCount(@Param("content_id") Long contentId);
 
   List<Content> findAllByCreatorName(String creatorName);
+
+  boolean existsByLink(String link);
 }

--- a/src/main/java/com/hyperlink/server/domain/content/domain/ContentRepository.java
+++ b/src/main/java/com/hyperlink/server/domain/content/domain/ContentRepository.java
@@ -1,6 +1,7 @@
 package com.hyperlink.server.domain.content.domain;
 
 import com.hyperlink.server.domain.content.domain.entity.Content;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -12,4 +13,5 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
   @Query("update Content c set c.viewCount = c.viewCount + 1 where c.id = :content_id")
   void updateViewCount(@Param("content_id") Long contentId);
 
+  List<Content> findAllByCreatorName(String creatorName);
 }

--- a/src/main/java/com/hyperlink/server/domain/content/dto/ContentCreationResponse.java
+++ b/src/main/java/com/hyperlink/server/domain/content/dto/ContentCreationResponse.java
@@ -1,0 +1,5 @@
+package com.hyperlink.server.domain.content.dto;
+
+public record ContentCreationResponse(String title, String link, String contentImgLink, String category, String creator) {
+
+}

--- a/src/main/java/com/hyperlink/server/domain/content/dto/ContentCreationResponse.java
+++ b/src/main/java/com/hyperlink/server/domain/content/dto/ContentCreationResponse.java
@@ -1,5 +1,0 @@
-package com.hyperlink.server.domain.content.dto;
-
-public record ContentCreationResponse(String title, String link, String contentImgLink, String category, String creator) {
-
-}

--- a/src/main/java/com/hyperlink/server/domain/content/dto/ContentEnrollResponse.java
+++ b/src/main/java/com/hyperlink/server/domain/content/dto/ContentEnrollResponse.java
@@ -1,0 +1,15 @@
+package com.hyperlink.server.domain.content.dto;
+
+import com.hyperlink.server.domain.category.domain.entity.Category;
+import com.hyperlink.server.domain.content.domain.entity.Content;
+import com.hyperlink.server.domain.creator.domain.entity.Creator;
+
+public record ContentEnrollResponse(String title, String link, String contentImgLink,
+                                    String category, String creator) {
+
+  public static Content toContent(ContentEnrollResponse contentEnrollResponse, Creator creator,
+      Category category) {
+    return new Content(contentEnrollResponse.title(), contentEnrollResponse.contentImgLink(),
+        contentEnrollResponse.link(), creator, category);
+  }
+}

--- a/src/main/java/com/hyperlink/server/domain/content/dto/ContentEnrollResponse.java
+++ b/src/main/java/com/hyperlink/server/domain/content/dto/ContentEnrollResponse.java
@@ -5,7 +5,7 @@ import com.hyperlink.server.domain.content.domain.entity.Content;
 import com.hyperlink.server.domain.creator.domain.entity.Creator;
 
 public record ContentEnrollResponse(String title, String link, String contentImgLink,
-                                    String category, String creator) {
+                                    String categoryName, String creatorName) {
 
   public static Content toContent(ContentEnrollResponse contentEnrollResponse, Creator creator,
       Category category) {

--- a/src/main/java/com/hyperlink/server/domain/creator/domain/CreatorRepository.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/domain/CreatorRepository.java
@@ -1,8 +1,9 @@
 package com.hyperlink.server.domain.creator.domain;
 
 import com.hyperlink.server.domain.creator.domain.entity.Creator;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CreatorRepository extends JpaRepository<Creator, Long> {
-
+  Optional<Creator> findByName(String name);
 }

--- a/src/main/java/com/hyperlink/server/domain/creator/domain/entity/Creator.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/domain/entity/Creator.java
@@ -53,4 +53,14 @@ public class Creator extends BaseEntity {
   @ManyToOne(fetch = FetchType.LAZY)
   private Category category;
 
+  public String getCategoryName() {
+    return category.getName();
+  }
+
+  public Creator(String name, String profileImgUrl, String description, Category category) {
+    this.name = name;
+    this.profileImgUrl = profileImgUrl;
+    this.description = description;
+    this.category = category;
+  }
 }

--- a/src/main/java/com/hyperlink/server/domain/creator/domain/entity/Creator.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/domain/entity/Creator.java
@@ -49,4 +49,8 @@ public class Creator extends BaseEntity {
     this.category = category;
   }
 
+  @JoinColumn(name = "category_id", nullable = false)
+  @ManyToOne(fetch = FetchType.LAZY)
+  private Category category;
+
 }

--- a/src/main/java/com/hyperlink/server/domain/creator/domain/entity/Creator.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/domain/entity/Creator.java
@@ -38,10 +38,6 @@ public class Creator extends BaseEntity {
   private Category category;
 
 
-  public String getCategoryName() {
-    return category.getName();
-  }
-
   public Creator(String name, String profileImgUrl, String description, Category category) {
     this.name = name;
     this.profileImgUrl = profileImgUrl;
@@ -49,18 +45,7 @@ public class Creator extends BaseEntity {
     this.category = category;
   }
 
-  @JoinColumn(name = "category_id", nullable = false)
-  @ManyToOne(fetch = FetchType.LAZY)
-  private Category category;
-
   public String getCategoryName() {
     return category.getName();
-  }
-
-  public Creator(String name, String profileImgUrl, String description, Category category) {
-    this.name = name;
-    this.profileImgUrl = profileImgUrl;
-    this.description = description;
-    this.category = category;
   }
 }

--- a/src/main/java/com/hyperlink/server/domain/memberCreator/domain/entity/MemberCreator.java~[#61] memberCreator table 생성
+++ b/src/main/java/com/hyperlink/server/domain/memberCreator/domain/entity/MemberCreator.java~[#61] memberCreator table 생성
@@ -1,0 +1,34 @@
+package com.hyperlink.server.domain.memberCreator.domain.entity;
+
+import com.hyperlink.server.domain.creator.domain.entity.Creator;
+import com.hyperlink.server.domain.member.domain.entity.Member;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberCreator {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "member_creator_id")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id")
+  private Member member;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "creator_id")
+  private Creator creator;
+}

--- a/src/main/java/com/hyperlink/server/domain/memberCreator/domain/entity/MemberCreator.java~develop/v0.1
+++ b/src/main/java/com/hyperlink/server/domain/memberCreator/domain/entity/MemberCreator.java~develop/v0.1
@@ -1,0 +1,34 @@
+package com.hyperlink.server.domain.memberCreator.domain.entity;
+
+import com.hyperlink.server.domain.creator.domain.entity.Creator;
+import com.hyperlink.server.domain.member.domain.entity.Member;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberCreator {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "member_creator_id")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id")
+  private Member member;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "creator_id")
+  private Creator creator;
+}

--- a/src/test/java/com/hyperlink/server/content/application/ContentServiceIntegrationTest.java
+++ b/src/test/java/com/hyperlink/server/content/application/ContentServiceIntegrationTest.java
@@ -1,7 +1,9 @@
 package com.hyperlink.server.content.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hyperlink.server.domain.category.domain.CategoryRepository;
 import com.hyperlink.server.domain.category.domain.entity.Category;
@@ -216,9 +218,11 @@ public class ContentServiceIntegrationTest {
     @Test
     @DisplayName("성공하면 컨텐츠를 추가한다.")
     public void insertContentSuccess() {
-      Long savedContentId = contentService.insertContent(
-          new ContentEnrollResponse("게시글", "link", "contentImgLink", category.getName(),
-              creator.getName()));
+      ContentEnrollResponse contentEnrollResponse = new ContentEnrollResponse("게시글", "link",
+          "contentImgLink", category.getName(),
+          creator.getName());
+
+      Long savedContentId = contentService.insertContent(contentEnrollResponse);
 
       assertThat(contentRepository.findById(savedContentId)).isPresent();
     }
@@ -228,19 +232,41 @@ public class ContentServiceIntegrationTest {
     class Failure {
 
       @Test
+      @DisplayName("이미 저장된 컨텐츠를 다시 저장하려고하면 저장하지 않고 -1을 반환한다.")
+      void insertFailIfExists() {
+        ContentEnrollResponse contentEnrollResponse = new ContentEnrollResponse("게시글", "link",
+            "contentImgLink", category.getName(),
+            creator.getName());
+        ContentEnrollResponse sameContentEnrollResponse = new ContentEnrollResponse("게시글", "link",
+            "contentImgLink", category.getName(),
+            creator.getName());
+
+        contentService.insertContent(contentEnrollResponse);
+        Long insertResult = contentService.insertContent(sameContentEnrollResponse);
+
+        assertEquals(-1L, (long) insertResult);
+      }
+
+      @Test
       @DisplayName("크리에이터의 이름이 잘못 입력되면 CreatorNotFoundException 을 발생한다.")
       void creatorNotFoundExceptionTest() {
-        assertThrows(CreatorNotFoundException.class, () -> contentService.insertContent(
-            new ContentEnrollResponse("게시글", "link", "contentImgLink", category.getName(),
-                "잘못된 크리에이터 명")));
+        ContentEnrollResponse contentEnrollResponse = new ContentEnrollResponse("게시글", "link",
+            "contentImgLink", category.getName(),
+            "잘못된 크리에이터 명");
+
+        assertThrows(CreatorNotFoundException.class,
+            () -> contentService.insertContent(contentEnrollResponse));
       }
 
       @Test
       @DisplayName("카테고리의 이름이 잘못 입력되면 CategoryNotFoundException 을 발생한다.")
       void categoryNotFoundExceptionTest() {
-        assertThrows(CategoryNotFoundException.class, () -> contentService.insertContent(
-            new ContentEnrollResponse("게시글", "link", "contentImgLink", "잘못된 카테고리명",
-                creator.getName())));
+        ContentEnrollResponse contentEnrollResponse = new ContentEnrollResponse("게시글", "link",
+            "contentImgLink", "잘못된 카테고리명",
+            creator.getName());
+
+        assertThrows(CategoryNotFoundException.class,
+            () -> contentService.insertContent(contentEnrollResponse));
       }
     }
   }

--- a/src/test/java/com/hyperlink/server/content/controller/ContentRabbitMQIntegrationTest.java
+++ b/src/test/java/com/hyperlink/server/content/controller/ContentRabbitMQIntegrationTest.java
@@ -1,0 +1,81 @@
+package com.hyperlink.server.content.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hyperlink.server.domain.category.domain.CategoryRepository;
+import com.hyperlink.server.domain.content.domain.ContentRepository;
+import com.hyperlink.server.domain.content.domain.entity.Content;
+import com.hyperlink.server.domain.content.dto.ContentEnrollResponse;
+import com.hyperlink.server.domain.creator.domain.CreatorRepository;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class ContentRabbitMQIntegrationTest {
+
+  @Autowired
+  RabbitTemplate rabbitTemplate;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @Autowired
+  CategoryRepository categoryRepository;
+
+  @Autowired
+  CreatorRepository creatorRepository;
+
+  @Autowired
+  ContentRepository contentRepository;
+
+  List<Content> allByCreatorName = new LinkedList<>();
+
+  @BeforeEach
+  void setUp() {
+    rabbitTemplate.setExchange("crawling-test");
+    rabbitTemplate.setRoutingKey("hello");
+    rabbitTemplate.setDefaultReceiveQueue("crawling-test-queue");
+  }
+
+  @AfterEach
+  void tearDown() {
+    contentRepository.deleteAllById(allByCreatorName.stream().map(Content::getId)
+        .collect(Collectors.toList()));
+  }
+
+  @Test
+  @DisplayName("RabbitMQ에 데이터를 넣으면 이는 DB로 저장된다.")
+  void rabbitMQSaveToDatabase() throws InterruptedException, JsonProcessingException {
+    String naverCreatorName = "네이버 D2 기술 블로그";
+    rabbitTemplate.convertAndSend(objectMapper.writeValueAsString(new ContentEnrollResponse("DEVIEW 2023 D-6! 부스를 소개합니다.",
+        "https://d2.naver.com/news/3775781",
+        "https://d2.naver.com/content/images/2023/02/-----------2023-02-06------2-53-17.png",
+        "develop", naverCreatorName)));
+
+    rabbitTemplate.convertAndSend(objectMapper.writeValueAsString(new ContentEnrollResponse("오프라인으로 돌아온 DEVIEW 2023, 미리보는 참가 신청 방법!",
+        "https://d2.naver.com/news/1888051",
+        "https://d2.naver.com/content/images/2023/02/D2-------------_170X120.png",
+        "develop", naverCreatorName)));
+
+    rabbitTemplate.convertAndSend(objectMapper.writeValueAsString(new ContentEnrollResponse("네이버 검색 SRE 2편 - 측정하지 않으면 개선할 수 없다! SRE KPI 개발기",
+        "https://d2.naver.com/helloworld/9231267",
+        "https://d2.naver.com/content/images/2023/01/d2_spring_2nd.png",
+        "develop", naverCreatorName)));
+
+    Thread.sleep(5000);
+    allByCreatorName = contentRepository.findAllByCreatorName(naverCreatorName);
+    assertEquals(3, allByCreatorName.size());
+
+  }
+
+}

--- a/src/test/java/com/hyperlink/server/content/controller/ContentRabbitMQIntegrationTest.java
+++ b/src/test/java/com/hyperlink/server/content/controller/ContentRabbitMQIntegrationTest.java
@@ -56,26 +56,32 @@ public class ContentRabbitMQIntegrationTest {
   @Test
   @DisplayName("RabbitMQ에 데이터를 넣으면 이는 DB로 저장된다.")
   void rabbitMQSaveToDatabase() throws InterruptedException, JsonProcessingException {
-    String naverCreatorName = "네이버 D2 기술 블로그";
-    rabbitTemplate.convertAndSend(objectMapper.writeValueAsString(new ContentEnrollResponse("DEVIEW 2023 D-6! 부스를 소개합니다.",
+    String naverCreatorName = "ybCreatorName(삭제x)";
+    ContentEnrollResponse contentEnrollResponse1 = new ContentEnrollResponse(
+        "DEVIEW 2023 D-6! 부스를 소개합니다.",
         "https://d2.naver.com/news/3775781",
         "https://d2.naver.com/content/images/2023/02/-----------2023-02-06------2-53-17.png",
-        "develop", naverCreatorName)));
+        "developCategoryTest(삭제x)", naverCreatorName);
 
-    rabbitTemplate.convertAndSend(objectMapper.writeValueAsString(new ContentEnrollResponse("오프라인으로 돌아온 DEVIEW 2023, 미리보는 참가 신청 방법!",
+    ContentEnrollResponse contentEnrollResponse2 = new ContentEnrollResponse(
+        "오프라인으로 돌아온 DEVIEW 2023, 미리보는 참가 신청 방법!",
         "https://d2.naver.com/news/1888051",
         "https://d2.naver.com/content/images/2023/02/D2-------------_170X120.png",
-        "develop", naverCreatorName)));
+        "developCategoryTest(삭제x)", naverCreatorName);
 
-    rabbitTemplate.convertAndSend(objectMapper.writeValueAsString(new ContentEnrollResponse("네이버 검색 SRE 2편 - 측정하지 않으면 개선할 수 없다! SRE KPI 개발기",
+    ContentEnrollResponse contentEnrollResponse3 = new ContentEnrollResponse(
+        "네이버 검색 SRE 2편 - 측정하지 않으면 개선할 수 없다! SRE KPI 개발기",
         "https://d2.naver.com/helloworld/9231267",
         "https://d2.naver.com/content/images/2023/01/d2_spring_2nd.png",
-        "develop", naverCreatorName)));
+        "developCategoryTest(삭제x)", naverCreatorName);
+
+    rabbitTemplate.convertAndSend(objectMapper.writeValueAsString(contentEnrollResponse1));
+    rabbitTemplate.convertAndSend(objectMapper.writeValueAsString(contentEnrollResponse2));
+    rabbitTemplate.convertAndSend(objectMapper.writeValueAsString(contentEnrollResponse3));
 
     Thread.sleep(5000);
     allByCreatorName = contentRepository.findAllByCreatorName(naverCreatorName);
     assertEquals(3, allByCreatorName.size());
-
   }
 
 }

--- a/src/test/java/com/hyperlink/server/creator/domain/CreatorRepositoryTest.java
+++ b/src/test/java/com/hyperlink/server/creator/domain/CreatorRepositoryTest.java
@@ -1,0 +1,38 @@
+package com.hyperlink.server.creator.domain;
+
+import com.hyperlink.server.domain.category.domain.CategoryRepository;
+import com.hyperlink.server.domain.category.domain.entity.Category;
+import com.hyperlink.server.domain.content.domain.entity.Content;
+import com.hyperlink.server.domain.creator.domain.CreatorRepository;
+import com.hyperlink.server.domain.creator.domain.entity.Creator;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+public class CreatorRepositoryTest {
+
+  @Autowired
+  CategoryRepository categoryRepository;
+
+  @Autowired
+  CreatorRepository creatorRepository;
+
+  @Test
+  @DisplayName("컨텐트를 이름으로 검색할 수 있다.")
+  void findContentByNameTest() {
+    Category category = new Category("개발");
+    Creator creator = new Creator("name", "profile", "description", category);
+    categoryRepository.save(category);
+    creatorRepository.save(creator);
+
+    Creator developCreator = creatorRepository.findByName("name").get();
+    Assertions.assertThat(developCreator.getName()).isEqualTo("name");
+  }
+
+}


### PR DESCRIPTION
### 변경 내용 요약
- 크롤링한 데이터를 메시지 큐를 통해 전달받아 DB에 저장합니다.

### 작업한 내용
- 메시지큐로 RabbitMQ 사용
- DB에 MQ에 쌓인 데이터 저장

### 기타사항
- prod 환경에서는 실제 DB에 저장되도록 세팅할 예정입니다.
- dev 환경에서는 실제 DB에 저장되지 않도록 테스트 코드에서만 사용합니다.

close #57 
