### PR TITLE
[#98] content 도메인 공통 DTO 변경

### DIFF
--- a/src/main/java/com/hyperlink/server/domain/content/application/ContentService.java
+++ b/src/main/java/com/hyperlink/server/domain/content/application/ContentService.java
@@ -3,6 +3,7 @@ package com.hyperlink.server.domain.content.application;
 import com.hyperlink.server.domain.content.domain.ContentRepository;
 import com.hyperlink.server.domain.content.domain.entity.Content;
 import com.hyperlink.server.domain.content.dto.ContentResponse;
+import com.hyperlink.server.domain.content.dto.GetContentsCommonResponse;
 import com.hyperlink.server.domain.content.dto.RecommendationCompanyResponse;
 import com.hyperlink.server.domain.content.dto.SearchResponse;
 import com.hyperlink.server.domain.content.exception.ContentNotFoundException;
@@ -39,14 +40,16 @@ public class ContentService {
 
   public SearchResponse search(Long memberId, String keyword, Pageable pageable) {
     List<String> keywords = splitSearchKeywords(keyword);
-    Slice<Content> searchResultContents = contentRepositoryCustom.searchByTitleContaining(keywords, pageable);
+    Slice<Content> searchResultContents = contentRepositoryCustom.searchByTitleContaining(keywords,
+        pageable);
 
-    List<ContentResponse> contentResponses = createContentResponses(memberId, searchResultContents);
-    return new SearchResponse(contentResponses, searchResultContents.hasNext(), keyword,
+    GetContentsCommonResponse contentResponses = createContentResponses(memberId,
+        searchResultContents);
+    return new SearchResponse(contentResponses, keyword,
         searchResultContents.getNumberOfElements());
   }
 
-  private List<ContentResponse> createContentResponses(Long memberId, Slice<Content> contents) {
+  private GetContentsCommonResponse createContentResponses(Long memberId, Slice<Content> contents) {
     List<ContentResponse> contentResponses = new ArrayList<>();
     for (Content content : contents) {
       boolean isBookmarked = memberContentService.isBookmarked(memberId, content.getId());
@@ -61,7 +64,7 @@ public class ContentService {
       contentResponses.add(contentResponse);
     }
 
-    return contentResponses;
+    return new GetContentsCommonResponse(contentResponses, contents.hasNext());
   }
 
   private List<String> splitSearchKeywords(String keyword) {

--- a/src/main/java/com/hyperlink/server/domain/content/dto/GetContentsCommonResponse.java
+++ b/src/main/java/com/hyperlink/server/domain/content/dto/GetContentsCommonResponse.java
@@ -1,0 +1,10 @@
+package com.hyperlink.server.domain.content.dto;
+
+import java.util.List;
+
+public record GetContentsCommonResponse(
+    List<ContentResponse> contents,
+    boolean hasNext
+) {
+
+}

--- a/src/main/java/com/hyperlink/server/domain/content/dto/SearchResponse.java
+++ b/src/main/java/com/hyperlink/server/domain/content/dto/SearchResponse.java
@@ -1,10 +1,7 @@
 package com.hyperlink.server.domain.content.dto;
 
-import java.util.List;
-
 public record SearchResponse(
-    List<ContentResponse> contents,
-    boolean hasNext,
+    GetContentsCommonResponse getContentsCommonResponse,
     String keyword,
     int resultCount
 ) {

--- a/src/test/java/com/hyperlink/server/content/controller/ContentControllerTest.java
+++ b/src/test/java/com/hyperlink/server/content/controller/ContentControllerTest.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hyperlink.server.domain.content.application.ContentService;
 import com.hyperlink.server.domain.content.controller.ContentController;
 import com.hyperlink.server.domain.content.dto.ContentResponse;
+import com.hyperlink.server.domain.content.dto.GetContentsCommonResponse;
 import com.hyperlink.server.domain.content.dto.RecommendationCompanyResponse;
 import com.hyperlink.server.domain.content.dto.SearchResponse;
 import java.util.List;
@@ -124,7 +125,9 @@ public class ContentControllerTest {
             "https://okky.kr/articles/503803", 4,
             100, false, false, "2023-02-17T12:30.334", recommendationCompanyResponses);
         List<ContentResponse> contentResponses = List.of(contentResponse);
-        SearchResponse searchResponse = new SearchResponse(contentResponses, true, keyword, 4);
+        GetContentsCommonResponse getContentsCommonResponse = new GetContentsCommonResponse(
+            contentResponses, true);
+        SearchResponse searchResponse = new SearchResponse(getContentsCommonResponse, keyword, 4);
 
         Long memberId = 1L;
         Pageable pageable = PageRequest.of(Integer.parseInt(page), Integer.parseInt(size));


### PR DESCRIPTION
### 변경 내용 요약
- content 도메인 공통 DTO 변경

### 작업한 내용
- 공통 DTO로 GetContentsCommonResponse를 새로 생성했어요

### 기타사항
- content domain API 개발 시 활용하시면 됩니다!

close #98 
