### PR TITLE
[#84] 히스토리 전체 내역 조회 API 구현 및 테스트

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -53,8 +53,11 @@ include::{snippets}/members/login/http-response.adoc[]
 include::{snippets}/members/login/response-headers.adoc[]
 include::{snippets}//members/login/response-fields.adoc[]
 
-== Creator
+== History
+=== 히스토리 전체 내역 조회
+operation::MemberHistoryControllerTest/getAllHistory[snippets='http-request,http-response,response-fields']
 
+== Creator
 === 비추천 크리에이터 추가
 
 operation::CreatorControllerTest/notRecommend[snippets='http-request,http-response']

--- a/src/main/java/com/hyperlink/server/domain/common/ContentDtoFactoryService.java
+++ b/src/main/java/com/hyperlink/server/domain/common/ContentDtoFactoryService.java
@@ -1,0 +1,38 @@
+package com.hyperlink.server.domain.common;
+
+import com.hyperlink.server.domain.content.domain.entity.Content;
+import com.hyperlink.server.domain.content.dto.ContentResponse;
+import com.hyperlink.server.domain.content.dto.GetContentsCommonResponse;
+import com.hyperlink.server.domain.content.dto.RecommendationCompanyResponse;
+import com.hyperlink.server.domain.memberContent.application.MemberContentService;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ContentDtoFactoryService {
+
+  private final MemberContentService memberContentService;
+
+  public GetContentsCommonResponse createContentResponses(Long memberId, List<Content> contents,
+      boolean hasNext) {
+    List<ContentResponse> contentResponses = new ArrayList<>();
+    for (Content content : contents) {
+      boolean isBookmarked = memberContentService.isBookmarked(memberId, content.getId());
+      boolean isLiked = content.getLikeCount() > 0;
+      // TODO : 회사 추천 리스트 추가
+      List<RecommendationCompanyResponse> recommendationCompanyResponses = new ArrayList<>();
+
+      ContentResponse contentResponse = new ContentResponse(content.getId(), content.getTitle(),
+          content.getCreator().getName(), content.getCreator().getId(), content.getContentImgUrl(),
+          content.getLink(), content.getLikeCount(), content.getViewCount(), isBookmarked, isLiked,
+          content.getCreatedAt().toString(), recommendationCompanyResponses);
+      contentResponses.add(contentResponse);
+    }
+
+    return new GetContentsCommonResponse(contentResponses, hasNext);
+  }
+
+}

--- a/src/main/java/com/hyperlink/server/domain/content/application/ContentService.java
+++ b/src/main/java/com/hyperlink/server/domain/content/application/ContentService.java
@@ -3,21 +3,18 @@ package com.hyperlink.server.domain.content.application;
 import com.hyperlink.server.domain.category.domain.CategoryRepository;
 import com.hyperlink.server.domain.category.domain.entity.Category;
 import com.hyperlink.server.domain.category.exception.CategoryNotFoundException;
+import com.hyperlink.server.domain.common.ContentDtoFactoryService;
 import com.hyperlink.server.domain.content.domain.ContentRepository;
 import com.hyperlink.server.domain.content.domain.entity.Content;
 import com.hyperlink.server.domain.content.dto.ContentEnrollResponse;
-import com.hyperlink.server.domain.content.dto.ContentResponse;
 import com.hyperlink.server.domain.content.dto.GetContentsCommonResponse;
-import com.hyperlink.server.domain.content.dto.RecommendationCompanyResponse;
 import com.hyperlink.server.domain.content.dto.SearchResponse;
 import com.hyperlink.server.domain.content.exception.ContentNotFoundException;
 import com.hyperlink.server.domain.content.infrastructure.ContentRepositoryCustom;
 import com.hyperlink.server.domain.creator.domain.CreatorRepository;
 import com.hyperlink.server.domain.creator.domain.entity.Creator;
 import com.hyperlink.server.domain.creator.exception.CreatorNotFoundException;
-import com.hyperlink.server.domain.memberContent.application.MemberContentService;
 import com.hyperlink.server.domain.memberHistory.application.MemberHistoryService;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -37,7 +34,7 @@ public class ContentService {
   private final CategoryRepository categoryRepository;
   private final CreatorRepository creatorRepository;
   private final ContentRepositoryCustom contentRepositoryCustom;
-  private final MemberContentService memberContentService;
+  private final ContentDtoFactoryService contentDtoFactoryService;
   private final MemberHistoryService memberHistoryService;
 
   public int getViewCount(Long contentId) {
@@ -60,34 +57,15 @@ public class ContentService {
     Slice<Content> searchResultContents = contentRepositoryCustom.searchByTitleContaining(keywords,
         pageable);
 
-    GetContentsCommonResponse contentResponses = createContentResponses(memberId,
-        searchResultContents);
+    GetContentsCommonResponse contentResponses = contentDtoFactoryService.createContentResponses(
+        memberId, searchResultContents.getContent(), searchResultContents.hasNext());
     return new SearchResponse(contentResponses, keyword,
         searchResultContents.getNumberOfElements());
-  }
-
-  private GetContentsCommonResponse createContentResponses(Long memberId, Slice<Content> contents) {
-    List<ContentResponse> contentResponses = new ArrayList<>();
-    for (Content content : contents) {
-      boolean isBookmarked = memberContentService.isBookmarked(memberId, content.getId());
-      boolean isLiked = content.getLikeCount() > 0;
-      // TODO : 회사 추천 리스트 추가
-      List<RecommendationCompanyResponse> recommendationCompanyResponses = new ArrayList<>();
-
-      ContentResponse contentResponse = new ContentResponse(content.getId(), content.getTitle(),
-          content.getCreator().getName(), content.getContentImgUrl(),
-          content.getLink(), content.getLikeCount(), content.getViewCount(), isBookmarked, isLiked,
-          content.getCreatedAt().toString(), recommendationCompanyResponses);
-      contentResponses.add(contentResponse);
-    }
-
-    return new GetContentsCommonResponse(contentResponses, contents.hasNext());
   }
 
   private List<String> splitSearchKeywords(String keyword) {
     return Arrays.asList(keyword.split(" "));
   }
-
 
   @Transactional
   public Long insertContent(ContentEnrollResponse contentEnrollResponse) {

--- a/src/main/java/com/hyperlink/server/domain/content/dto/ContentResponse.java
+++ b/src/main/java/com/hyperlink/server/domain/content/dto/ContentResponse.java
@@ -6,6 +6,7 @@ public record ContentResponse(
     Long contentId,
     String title,
     String creatorName,
+    Long creatorId,
     String contentImgUrl,
     String link,
     int likeCount,

--- a/src/main/java/com/hyperlink/server/domain/memberHistory/application/MemberHistoryService.java
+++ b/src/main/java/com/hyperlink/server/domain/memberHistory/application/MemberHistoryService.java
@@ -1,20 +1,26 @@
 package com.hyperlink.server.domain.memberHistory.application;
 
+import com.hyperlink.server.domain.common.ContentDtoFactoryService;
 import com.hyperlink.server.domain.content.domain.ContentRepository;
 import com.hyperlink.server.domain.content.domain.entity.Content;
+import com.hyperlink.server.domain.content.dto.GetContentsCommonResponse;
 import com.hyperlink.server.domain.content.exception.ContentNotFoundException;
 import com.hyperlink.server.domain.member.domain.MemberRepository;
 import com.hyperlink.server.domain.member.domain.entity.Member;
 import com.hyperlink.server.domain.member.exception.MemberNotFoundException;
 import com.hyperlink.server.domain.memberHistory.domain.entity.MemberHistory;
 import com.hyperlink.server.domain.memberHistory.domain.entity.MemberHistoryRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class MemberHistoryService {
 
+  private final ContentDtoFactoryService contentDtoFactoryService;
   private final MemberHistoryRepository memberHistoryRepository;
   private final MemberRepository memberRepository;
   private final ContentRepository contentRepository;
@@ -28,4 +34,12 @@ public class MemberHistoryService {
     memberHistoryRepository.save(memberHistory);
   }
 
+  public GetContentsCommonResponse getAllHistory(Long memberId, Pageable pageable) {
+    Slice<MemberHistory> findMemberHistory = memberHistoryRepository.findSliceByMemberId(memberId,
+        pageable);
+    List<Content> contents = findMemberHistory.get().map(MemberHistory::getContent)
+        .toList();
+
+    return contentDtoFactoryService.createContentResponses(memberId, contents, findMemberHistory.hasNext());
+  }
 }

--- a/src/main/java/com/hyperlink/server/domain/memberHistory/controller/MemberHistoryController.java
+++ b/src/main/java/com/hyperlink/server/domain/memberHistory/controller/MemberHistoryController.java
@@ -1,0 +1,38 @@
+package com.hyperlink.server.domain.memberHistory.controller;
+
+import com.hyperlink.server.domain.auth.token.exception.TokenNotExistsException;
+import com.hyperlink.server.domain.content.dto.GetContentsCommonResponse;
+import com.hyperlink.server.domain.memberHistory.application.MemberHistoryService;
+import com.hyperlink.server.global.config.LoginMemberId;
+import java.util.Optional;
+import javax.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+public class MemberHistoryController {
+
+  private final MemberHistoryService memberHistoryService;
+
+  @GetMapping("/history")
+  @ResponseStatus(HttpStatus.OK)
+  public GetContentsCommonResponse getAllHistory(@LoginMemberId Optional<Long> memberId,
+      @RequestParam("page") @NotNull int page,
+      @RequestParam("size") @NotNull int size) {
+    if (memberId.isEmpty()) {
+      throw new TokenNotExistsException();
+    }
+    Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+    return memberHistoryService.getAllHistory(memberId.get(), pageable);
+  }
+}

--- a/src/main/java/com/hyperlink/server/domain/memberHistory/domain/entity/MemberHistory.java
+++ b/src/main/java/com/hyperlink/server/domain/memberHistory/domain/entity/MemberHistory.java
@@ -1,5 +1,6 @@
 package com.hyperlink.server.domain.memberHistory.domain.entity;
 
+import com.hyperlink.server.domain.common.BaseEntity;
 import com.hyperlink.server.domain.content.domain.entity.Content;
 import com.hyperlink.server.domain.member.domain.entity.Member;
 import javax.persistence.Column;
@@ -17,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MemberHistory {
+public class MemberHistory extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/hyperlink/server/domain/memberHistory/domain/entity/MemberHistoryRepository.java
+++ b/src/main/java/com/hyperlink/server/domain/memberHistory/domain/entity/MemberHistoryRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberHistoryRepository extends JpaRepository<MemberHistory, Long> {
 
-  List<MemberHistory> findByMemberId(Long memberId);
+  List<MemberHistory> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/hyperlink/server/domain/memberHistory/domain/entity/MemberHistoryRepository.java
+++ b/src/main/java/com/hyperlink/server/domain/memberHistory/domain/entity/MemberHistoryRepository.java
@@ -1,9 +1,13 @@
 package com.hyperlink.server.domain.memberHistory.domain.entity;
 
 import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberHistoryRepository extends JpaRepository<MemberHistory, Long> {
 
   List<MemberHistory> findAllByMemberId(Long memberId);
+
+  Slice<MemberHistory> findSliceByMemberId(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/hyperlink/server/domain/notRecommendCreator/domain/entity/NotRecommendCreator.java
+++ b/src/main/java/com/hyperlink/server/domain/notRecommendCreator/domain/entity/NotRecommendCreator.java
@@ -1,5 +1,6 @@
 package com.hyperlink.server.domain.notRecommendCreator.domain.entity;
 
+import com.hyperlink.server.domain.common.BaseEntity;
 import com.hyperlink.server.domain.creator.domain.entity.Creator;
 import com.hyperlink.server.domain.member.domain.entity.Member;
 import javax.persistence.Column;
@@ -17,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class NotRecommendCreator {
+public class NotRecommendCreator extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/test/java/com/hyperlink/server/AuthSetupForMock.java
+++ b/src/test/java/com/hyperlink/server/AuthSetupForMock.java
@@ -12,7 +12,7 @@ public class AuthSetupForMock {
   @MockBean
   protected AuthTokenExtractor authTokenExtractor;
 
-  protected String authorizationHeader = "Bearer Token";
+  protected String authorizationHeader = "Bearer ${ACCESS_TOKEN}";
 
   protected Long memberId = 1L;
 

--- a/src/test/java/com/hyperlink/server/memberHistory/application/MemberHistoryIntegrationTest.java
+++ b/src/test/java/com/hyperlink/server/memberHistory/application/MemberHistoryIntegrationTest.java
@@ -61,7 +61,7 @@ class MemberHistoryIntegrationTest {
 
     memberHistoryService.insertMemberHistory(member.getId(), content.getId());
 
-    List<MemberHistory> findMemberHistory = memberHistoryRepository.findByMemberId(member.getId());
+    List<MemberHistory> findMemberHistory = memberHistoryRepository.findAllByMemberId(member.getId());
     assertThat(findMemberHistory.get(0).getMember()).isEqualTo(member);
     assertThat(findMemberHistory.get(0).getContent()).isEqualTo(content);
   }

--- a/src/test/java/com/hyperlink/server/memberHistory/application/MemberHistoryIntegrationTest.java
+++ b/src/test/java/com/hyperlink/server/memberHistory/application/MemberHistoryIntegrationTest.java
@@ -6,6 +6,8 @@ import com.hyperlink.server.domain.category.domain.CategoryRepository;
 import com.hyperlink.server.domain.category.domain.entity.Category;
 import com.hyperlink.server.domain.content.domain.ContentRepository;
 import com.hyperlink.server.domain.content.domain.entity.Content;
+import com.hyperlink.server.domain.content.dto.ContentResponse;
+import com.hyperlink.server.domain.content.dto.GetContentsCommonResponse;
 import com.hyperlink.server.domain.creator.domain.CreatorRepository;
 import com.hyperlink.server.domain.creator.domain.entity.Creator;
 import com.hyperlink.server.domain.member.domain.MemberRepository;
@@ -13,12 +15,18 @@ import com.hyperlink.server.domain.member.domain.entity.Member;
 import com.hyperlink.server.domain.memberHistory.application.MemberHistoryService;
 import com.hyperlink.server.domain.memberHistory.domain.entity.MemberHistory;
 import com.hyperlink.server.domain.memberHistory.domain.entity.MemberHistoryRepository;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
@@ -61,9 +69,55 @@ class MemberHistoryIntegrationTest {
 
     memberHistoryService.insertMemberHistory(member.getId(), content.getId());
 
-    List<MemberHistory> findMemberHistory = memberHistoryRepository.findAllByMemberId(member.getId());
+    List<MemberHistory> findMemberHistory = memberHistoryRepository.findAllByMemberId(
+        member.getId());
     assertThat(findMemberHistory.get(0).getMember()).isEqualTo(member);
     assertThat(findMemberHistory.get(0).getContent()).isEqualTo(content);
+  }
+
+  @Nested
+  @DisplayName("히스토리 전체 조회 메소드는")
+  class GetAllHistoryTest {
+
+    Member member;
+    List<Content> contents = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+      member = new Member("email", "nickname", "career", "3", "profileImgUrl");
+      memberRepository.save(member);
+
+      LocalDateTime now = LocalDateTime.now();
+      contents.add(new Content("개발", "ImgUrl", "link", creator, category));
+      contents.add(new Content("개발짱", "ImgUrl", "link", creator, category));
+      contents.add(new Content("짱개발짱", "ImgUrl", "link", creator, category));
+      contents.add(new Content("개발자의 성장하는 삶", "ImgUrl", "link", creator, category));
+      contents.add(new Content("키가 쑥쑥 성장판", "ImgUrl", "link", creator, category));
+      contents.add(new Content("짱코딩짱", "ImgUrl", "link", creator, category));
+
+      contentRepository.saveAll(contents);
+
+      for (Content content : contents) {
+        MemberHistory memberHistory = new MemberHistory(member, content);
+        memberHistoryRepository.save(memberHistory);
+      }
+    }
+
+    @Test
+    @DisplayName("전체 히스토리 리스트를 요청에 맞는 size로 응답한다")
+    void getAllHistoryTest() {
+      Long memberId = member.getId();
+      final int page = 0;
+      final int size = 2;
+      Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+
+      GetContentsCommonResponse findAllHistory = memberHistoryService.getAllHistory(memberId,
+          pageable);
+      List<ContentResponse> contentResponses = findAllHistory.contents();
+
+      assertThat(findAllHistory.hasNext()).isTrue();
+      assertThat(contentResponses).hasSize(2);
+    }
   }
 
 }

--- a/src/test/java/com/hyperlink/server/memberHistory/controller/MemberHistoryControllerTest.java
+++ b/src/test/java/com/hyperlink/server/memberHistory/controller/MemberHistoryControllerTest.java
@@ -1,10 +1,12 @@
-package com.hyperlink.server.content.controller;
+package com.hyperlink.server.memberHistory.controller;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
@@ -12,118 +14,79 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.hyperlink.server.domain.content.application.ContentService;
-import com.hyperlink.server.domain.content.controller.ContentController;
+import com.hyperlink.server.AuthSetupForMock;
+import com.hyperlink.server.domain.auth.token.JwtTokenProvider;
 import com.hyperlink.server.domain.content.dto.ContentResponse;
 import com.hyperlink.server.domain.content.dto.GetContentsCommonResponse;
 import com.hyperlink.server.domain.content.dto.RecommendationCompanyResponse;
-import com.hyperlink.server.domain.content.dto.SearchResponse;
+import com.hyperlink.server.domain.memberHistory.application.MemberHistoryService;
+import com.hyperlink.server.domain.memberHistory.controller.MemberHistoryController;
 import java.util.List;
-import javax.validation.ValidationException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.HttpHeaders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
-@WebMvcTest(ContentController.class)
+@WebMvcTest(MemberHistoryController.class)
 @MockBean(JpaMetamodelMappingContext.class)
 @AutoConfigureRestDocs
 @AutoConfigureMockMvc
-public class ContentControllerTest {
+public class MemberHistoryControllerTest extends AuthSetupForMock {
 
   @MockBean
-  ContentService contentService;
+  MemberHistoryService memberHistoryService;
   @Autowired
   MockMvc mockMvc;
-  @Autowired
-  ObjectMapper objectMapper;
+  @MockBean
+  JwtTokenProvider jwtTokenProvider;
 
   @Nested
-  @DisplayName("조회수 추가 API는")
-  class AddInquiryOfContent {
+  @DisplayName("히스토리 전체 조회 API는")
+  class GetAllHistory {
 
     @Nested
-    @DisplayName("유효한 요청값이 들어오면")
-    class Success {
-
-      Long contentId = 1L;
-
-      @Test
-      @DisplayName("조회수 추가에 성공하고 OK와 최종 조회수를 응답한다")
-      void addInquiryOfContentTest() throws Exception {
-        mockMvc.perform(
-                patch("/contents/" + contentId + "/view")
-                //                    .header("AccessToken", accessToken)
-            )
-            .andExpect(status().isOk())
-            .andDo(
-                document(
-                    "ContentControllerTest/addInquiryOfContent",
-                    preprocessRequest(prettyPrint()),
-                    preprocessResponse(prettyPrint()),
-                    requestHeaders(
-                        // TODO : jwt
-//                        headerWithName("AccessToken").description("jwt header")
-                    ),
-                    responseFields(
-                        fieldWithPath("viewCount").type(JsonFieldType.NUMBER)
-                            .description("조회수 추가 완료 후 최종 조회수")
-                    )
-                )
-            );
-      }
-    }
-  }
-
-  @Nested
-  @DisplayName("검색 API는")
-  class SearchContent {
-
-    String page = "0", size = "10";
-
-    @Nested
-    @DisplayName("keyword에 공백이 들어오면")
-    class NullOrBlank {
+    @DisplayName("page 혹은 size에 null 값이 들어오면")
+    class Null {
 
       @ParameterizedTest
-      @EmptySource
+      @NullSource
       @DisplayName("BadRequest를 응답한다")
-      void badRequest(String keyword) throws Exception {
+      void failRequestTest(Integer nullValue) throws Exception {
+        authSetup();
+
         mockMvc.perform(
-                get("/contents/search")
-                    .param("keyword", keyword)
-                    .param("page", page)
-                    .param("size", size)
-                    .characterEncoding("UTF-8")
-            )
+                get("/history")
+                    .param("page", String.valueOf(nullValue))
+                    .param("size", String.valueOf(nullValue))
+                    .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                )
             .andExpect(status().isBadRequest())
-            .andExpect(response -> Assertions.assertTrue(
-                response.getResolvedException() instanceof ValidationException));
+            .andExpect(response -> assertTrue(
+                response.getResolvedException() instanceof MethodArgumentTypeMismatchException));
       }
     }
 
     @Nested
     @DisplayName("유효한 요청값이 들어오면")
     class Success {
-
-      String keyword = "개발 성장";
+      String page = "0", size = "10";
 
       @Test
-      @DisplayName("검색결과 리스트를 응답한다")
-      void searchContentsTest() throws Exception {
+      @DisplayName("OK와 유저의 히스토리 전체 내역을 응답한다")
+      void addInquiryOfContentTest() throws Exception {
+        authSetup();
+
         List<RecommendationCompanyResponse> recommendationCompanyResponses = List.of(
             new RecommendationCompanyResponse("네이버", "https://imglogo.com"));
         ContentResponse contentResponse = new ContentResponse(27L, "개발자의 삶", "슈카", 2L,
@@ -132,28 +95,22 @@ public class ContentControllerTest {
         List<ContentResponse> contentResponses = List.of(contentResponse);
         GetContentsCommonResponse getContentsCommonResponse = new GetContentsCommonResponse(
             contentResponses, true);
-        SearchResponse searchResponse = new SearchResponse(getContentsCommonResponse, keyword, 4);
 
-        Long memberId = 1L;
-        Pageable pageable = PageRequest.of(Integer.parseInt(page), Integer.parseInt(size));
-        doReturn(searchResponse).when(contentService).search(memberId, keyword, pageable);
+        doReturn(getContentsCommonResponse).when(memberHistoryService).getAllHistory(any(), any());
 
         mockMvc.perform(
-                get("/contents/search")
-                    .param("keyword", keyword)
+                get("/history")
                     .param("page", page)
                     .param("size", size)
-//                    .header("AccessToken", accessToken)
-                    .characterEncoding("UTF-8")
+                    .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
             ).andExpect(status().isOk())
             .andDo(
                 document(
-                    "ContentControllerTest/search",
+                    "MemberHistoryControllerTest/getAllHistory",
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
                     requestHeaders(
-                        // TODO : jwt
-//                        headerWithName("AccessToken").description("jwt header")
+                        headerWithName(HttpHeaders.AUTHORIZATION).description("jwt header")
                     ),
                     responseFields(
                         fieldWithPath("contents.[].contentId").type(JsonFieldType.NUMBER)
@@ -186,10 +143,7 @@ public class ContentControllerTest {
                             "contents.[].recommendationCompanies.[].companyLogoImgUrl").type(
                             JsonFieldType.STRING).description("회사 로고 URL"),
                         fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN)
-                            .description("다음 페이지 존재여부"),
-                        fieldWithPath("keyword").type(JsonFieldType.STRING).description("검색 키워드"),
-                        fieldWithPath("resultCount").type(JsonFieldType.NUMBER)
-                            .description("검색 결과 전체 개수")
+                            .description("다음 페이지 존재여부")
                     )
                 )
             );


### PR DESCRIPTION
### 변경 내용 요약
- 히스토리 전체 내역 조회 API 구현 및 테스트 작성
- content domain 공통 응답 DTO 생성 로직 분리 (ContentDtoFactoryService)

### 작업한 내용
- 유저의 전체 히스토리 내역을 조회하는 API를 개발했어요!
- content domain 공통 응답 DTO 생성 로직을 분리했어요!
- 기존에 memberContent 패키지 내부에 있던 AuthSetupForMock **공통 클래스**를 외부로 변경했어요 !

close #84 
