### PR TITLE
[#80] 기존 개발 완료된 API에 jwt 헤더 추가, 검색 API 오류 수정

### DIFF
--- a/src/main/java/com/hyperlink/server/domain/content/application/ContentService.java
+++ b/src/main/java/com/hyperlink/server/domain/content/application/ContentService.java
@@ -17,6 +17,7 @@ import com.hyperlink.server.domain.creator.exception.CreatorNotFoundException;
 import com.hyperlink.server.domain.memberHistory.application.MemberHistoryService;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -45,11 +46,10 @@ public class ContentService {
   }
 
   @Transactional
-  public void addView(Long memberId, Long contentId) {
+  public void addView(Optional<Long> optionalMemberId, Long contentId) {
     contentRepository.updateViewCount(contentId);
-    if (memberId != null) {
-      memberHistoryService.insertMemberHistory(memberId, contentId);
-    }
+    optionalMemberId.ifPresent(
+        memberId -> memberHistoryService.insertMemberHistory(memberId, contentId));
   }
 
   public SearchResponse search(Long memberId, String keyword, Pageable pageable) {
@@ -76,7 +76,7 @@ public class ContentService {
 
     Content content = ContentEnrollResponse.toContent(contentEnrollResponse, creator, category);
     boolean exist = contentRepository.existsByLink(content.getLink());
-    if(exist) {
+    if (exist) {
       log.info("이미 존재하는 컨텐츠입니다. {}", contentEnrollResponse);
       return -1L;
     }

--- a/src/main/java/com/hyperlink/server/domain/content/application/ContentService.java
+++ b/src/main/java/com/hyperlink/server/domain/content/application/ContentService.java
@@ -54,7 +54,7 @@ public class ContentService {
 
   public SearchResponse search(Long memberId, String keyword, Pageable pageable) {
     List<String> keywords = splitSearchKeywords(keyword);
-    Slice<Content> searchResultContents = contentRepositoryCustom.searchByTitleContaining(keywords,
+    Slice<Content> searchResultContents = contentRepositoryCustom.searchByTitleContainingOrderByLatest(keywords,
         pageable);
 
     GetContentsCommonResponse contentResponses = contentDtoFactoryService.createContentResponses(

--- a/src/main/java/com/hyperlink/server/domain/content/controller/ContentController.java
+++ b/src/main/java/com/hyperlink/server/domain/content/controller/ContentController.java
@@ -32,25 +32,22 @@ public class ContentController {
 
   @PatchMapping("/{contentId}/view")
   @ResponseStatus(HttpStatus.OK)
-  public PatchInquiryResponse addViewOfContent(@PathVariable("contentId") long contentId) {
-    // TODO : JWT
-    Long memberId = 1L;
-    contentService.addView(memberId, contentId);
+  public PatchInquiryResponse addViewOfContent(@LoginMemberId Optional<Long> optionalMemberId,
+      @PathVariable("contentId") long contentId) {
+    contentService.addView(optionalMemberId, contentId);
     int viewCount = contentService.getViewCount(contentId);
     return new PatchInquiryResponse(viewCount);
   }
 
   @GetMapping("/search")
   @ResponseStatus(HttpStatus.OK)
-  public SearchResponse search(@LoginMemberId Optional<Long> memberId,
+  public SearchResponse search(@LoginMemberId Optional<Long> optionalMemberId,
       @RequestParam("keyword") @NotBlank String keyword,
       @RequestParam("page") @NotNull int page,
       @RequestParam("size") @NotNull int size) {
-    if (memberId.isEmpty()) {
-      throw new TokenNotExistsException();
-    }
+    Long memberId = optionalMemberId.orElseThrow(TokenNotExistsException::new);
     Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
-    return contentService.search(memberId.get(), keyword, pageable);
+    return contentService.search(memberId, keyword, pageable);
   }
 
 }

--- a/src/main/java/com/hyperlink/server/domain/content/controller/ContentController.java
+++ b/src/main/java/com/hyperlink/server/domain/content/controller/ContentController.java
@@ -46,7 +46,7 @@ public class ContentController {
       @RequestParam("page") @NotNull int page,
       @RequestParam("size") @NotNull int size) {
     Long memberId = optionalMemberId.orElseThrow(TokenNotExistsException::new);
-    Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+    Pageable pageable = PageRequest.of(page, size);
     return contentService.search(memberId, keyword, pageable);
   }
 

--- a/src/main/java/com/hyperlink/server/domain/content/infrastructure/ContentRepositoryCustom.java
+++ b/src/main/java/com/hyperlink/server/domain/content/infrastructure/ContentRepositoryCustom.java
@@ -18,7 +18,7 @@ public class ContentRepositoryCustom {
 
   private final JPAQueryFactory queryFactory;
 
-  public Slice<Content> searchByTitleContaining(List<String> keywords, Pageable pageable) {
+  public Slice<Content> searchByTitleContainingOrderByLatest(List<String> keywords, Pageable pageable) {
     BooleanBuilder builder = new BooleanBuilder();
     for (String keyword : keywords) {
       builder.or(content.title.contains(keyword));
@@ -29,6 +29,7 @@ public class ContentRepositoryCustom {
         .where(builder)
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
+        .orderBy(content.createdAt.desc())
         .fetch();
 
     long size = queryFactory.selectFrom(content)

--- a/src/main/java/com/hyperlink/server/domain/creator/application/CreatorService.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/application/CreatorService.java
@@ -43,6 +43,5 @@ public class CreatorService {
     NotRecommendCreator notRecommendCreator = new NotRecommendCreator(member, creator);
 
     return notRecommendCreatorRepository.save(notRecommendCreator);
-
   }
 }

--- a/src/main/java/com/hyperlink/server/domain/creator/controller/CreatorController.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/controller/CreatorController.java
@@ -1,8 +1,11 @@
 package com.hyperlink.server.domain.creator.controller;
 
+import com.hyperlink.server.domain.auth.token.exception.TokenNotExistsException;
 import com.hyperlink.server.domain.creator.application.CreatorService;
 import com.hyperlink.server.domain.creator.dto.CreatorEnrollRequest;
 import com.hyperlink.server.domain.creator.dto.CreatorEnrollResponse;
+import com.hyperlink.server.global.config.LoginMemberId;
+import java.util.Optional;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -28,10 +31,9 @@ public class CreatorController {
 
   @PostMapping("/creators/{creatorId}/not-recommend")
   @ResponseStatus(HttpStatus.OK)
-  public void notRecommend(@PathVariable("creatorId") Long creatorId) {
-    // TODO : JWT
-    Long memberId = 1L;
+  public void notRecommend(@LoginMemberId Optional<Long> optionalMemberId,
+      @PathVariable("creatorId") Long creatorId) {
+    Long memberId = optionalMemberId.orElseThrow(TokenNotExistsException::new);
     creatorService.notRecommend(memberId, creatorId);
-
   }
 }

--- a/src/main/java/com/hyperlink/server/domain/memberContent/controller/MemberContentController.java
+++ b/src/main/java/com/hyperlink/server/domain/memberContent/controller/MemberContentController.java
@@ -1,6 +1,9 @@
 package com.hyperlink.server.domain.memberContent.controller;
 
+import com.hyperlink.server.domain.auth.token.exception.TokenNotExistsException;
 import com.hyperlink.server.domain.memberContent.application.MemberContentService;
+import com.hyperlink.server.global.config.LoginMemberId;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -17,7 +20,9 @@ public class MemberContentController {
 
   @PostMapping("/bookmark/{contentId}")
   @ResponseStatus(HttpStatus.OK)
-  public void includeCreateOrDeleteBookmark(Long memberId, @PathVariable("contentId") Long contentId, @RequestParam("type") boolean type) {
+  public void includeCreateOrDeleteBookmark(@LoginMemberId Optional<Long> optionalMemberId,
+      @PathVariable("contentId") Long contentId, @RequestParam("type") boolean type) {
+    Long memberId = optionalMemberId.orElseThrow(TokenNotExistsException::new);
     if (type) {
       memberContentService.createBookmark(memberId, contentId);
     } else {

--- a/src/test/java/com/hyperlink/server/content/application/ContentServiceIntegrationTest.java
+++ b/src/test/java/com/hyperlink/server/content/application/ContentServiceIntegrationTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hyperlink.server.domain.category.domain.CategoryRepository;
 import com.hyperlink.server.domain.category.domain.entity.Category;
@@ -19,11 +18,10 @@ import com.hyperlink.server.domain.content.dto.SearchResponse;
 import com.hyperlink.server.domain.content.exception.ContentNotFoundException;
 import com.hyperlink.server.domain.creator.domain.CreatorRepository;
 import com.hyperlink.server.domain.creator.domain.entity.Creator;
+import com.hyperlink.server.domain.creator.exception.CreatorNotFoundException;
 import com.hyperlink.server.domain.member.domain.MemberRepository;
 import com.hyperlink.server.domain.member.domain.entity.Member;
 import com.hyperlink.server.domain.memberHistory.application.MemberHistoryService;
-import com.hyperlink.server.domain.creator.exception.CreatorNotFoundException;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -98,7 +96,7 @@ public class ContentServiceIntegrationTest {
       contentRepository.save(content);
       int inquiryCountBeforeAdd = content.getViewCount();
 
-      contentService.addView(null, content.getId());
+      contentService.addView(Optional.empty(), content.getId());
 
       int findInquiry = contentService.getViewCount(content.getId());
 
@@ -218,7 +216,7 @@ public class ContentServiceIntegrationTest {
 
       @Override
       public void run() {
-        contentService.addView(null, contentId);
+        contentService.addView(Optional.empty(), contentId);
         countDownLatch.countDown();
       }
     }

--- a/src/test/java/com/hyperlink/server/content/application/ContentServiceIntegrationTest.java
+++ b/src/test/java/com/hyperlink/server/content/application/ContentServiceIntegrationTest.java
@@ -26,6 +26,7 @@ import com.hyperlink.server.domain.creator.exception.CreatorNotFoundException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
@@ -124,7 +125,7 @@ public class ContentServiceIntegrationTest {
       @Test
       @DisplayName("조회수가 +1 처리되고, 히스토리 내역에 추가된 데이터가 없다")
       void addViewPlusOneAndNothingChangeHistory() {
-        Long memberId = null;
+        Optional<Long> memberId = Optional.empty();
         Content content = new Content("title", "contentImgUrl", "link", creator, category);
         content = contentRepository.save(content);
         int beforeViewCount = content.getViewCount();
@@ -150,7 +151,7 @@ public class ContentServiceIntegrationTest {
         Content content = new Content("title", "contentImgUrl", "link", creator, category);
         content = contentRepository.save(content);
 
-        contentService.addView(member.getId(), content.getId());
+        contentService.addView(Optional.of(member.getId()), content.getId());
 
         verify(memberHistoryService, times(1)).insertMemberHistory(any(), any());
       }

--- a/src/test/java/com/hyperlink/server/content/controller/ContentControllerTest.java
+++ b/src/test/java/com/hyperlink/server/content/controller/ContentControllerTest.java
@@ -1,6 +1,7 @@
 package com.hyperlink.server.content.controller;
 
 import static org.mockito.Mockito.doReturn;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
@@ -13,6 +14,8 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hyperlink.server.AuthSetupForMock;
+import com.hyperlink.server.domain.auth.token.JwtTokenProvider;
 import com.hyperlink.server.domain.content.application.ContentService;
 import com.hyperlink.server.domain.content.controller.ContentController;
 import com.hyperlink.server.domain.content.dto.ContentResponse;
@@ -35,6 +38,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.HttpHeaders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -42,7 +46,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @MockBean(JpaMetamodelMappingContext.class)
 @AutoConfigureRestDocs
 @AutoConfigureMockMvc
-public class ContentControllerTest {
+public class ContentControllerTest extends AuthSetupForMock {
 
   @MockBean
   ContentService contentService;
@@ -50,6 +54,8 @@ public class ContentControllerTest {
   MockMvc mockMvc;
   @Autowired
   ObjectMapper objectMapper;
+  @MockBean
+  JwtTokenProvider jwtTokenProvider;
 
   @Nested
   @DisplayName("조회수 추가 API는")
@@ -107,6 +113,7 @@ public class ContentControllerTest {
                     .param("keyword", keyword)
                     .param("page", page)
                     .param("size", size)
+                    .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
                     .characterEncoding("UTF-8")
             )
             .andExpect(status().isBadRequest())
@@ -124,6 +131,8 @@ public class ContentControllerTest {
       @Test
       @DisplayName("검색결과 리스트를 응답한다")
       void searchContentsTest() throws Exception {
+        authSetup();
+
         List<RecommendationCompanyResponse> recommendationCompanyResponses = List.of(
             new RecommendationCompanyResponse("네이버", "https://imglogo.com"));
         ContentResponse contentResponse = new ContentResponse(27L, "개발자의 삶", "슈카", 2L,
@@ -143,7 +152,7 @@ public class ContentControllerTest {
                     .param("keyword", keyword)
                     .param("page", page)
                     .param("size", size)
-//                    .header("AccessToken", accessToken)
+                    .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
                     .characterEncoding("UTF-8")
             ).andExpect(status().isOk())
             .andDo(
@@ -152,40 +161,39 @@ public class ContentControllerTest {
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
                     requestHeaders(
-                        // TODO : jwt
-//                        headerWithName("AccessToken").description("jwt header")
+                        headerWithName(HttpHeaders.AUTHORIZATION).description("jwt header")
                     ),
                     responseFields(
-                        fieldWithPath("contents.[].contentId").type(JsonFieldType.NUMBER)
+                        fieldWithPath("getContentsCommonResponse.contents.[].contentId").type(JsonFieldType.NUMBER)
                             .description("컨텐츠 id"),
-                        fieldWithPath("contents.[].title").type(JsonFieldType.STRING)
+                        fieldWithPath("getContentsCommonResponse.contents.[].title").type(JsonFieldType.STRING)
                             .description("컨텐츠 제목"),
-                        fieldWithPath("contents.[].creatorName").type(JsonFieldType.STRING)
+                        fieldWithPath("getContentsCommonResponse.contents.[].creatorName").type(JsonFieldType.STRING)
                             .description("크리에이터 이름"),
-                        fieldWithPath("contents.[].creatorId").type(JsonFieldType.NUMBER)
+                        fieldWithPath("getContentsCommonResponse.contents.[].creatorId").type(JsonFieldType.NUMBER)
                             .description("크리에이터 id"),
-                        fieldWithPath("contents.[].contentImgUrl").type(JsonFieldType.STRING)
+                        fieldWithPath("getContentsCommonResponse.contents.[].contentImgUrl").type(JsonFieldType.STRING)
                             .description("컨텐츠 이미지 URL"),
-                        fieldWithPath("contents.[].link").type(JsonFieldType.STRING)
+                        fieldWithPath("getContentsCommonResponse.contents.[].link").type(JsonFieldType.STRING)
                             .description("컨텐츠 연결 외부 링크"),
-                        fieldWithPath("contents.[].likeCount").type(JsonFieldType.NUMBER)
+                        fieldWithPath("getContentsCommonResponse.contents.[].likeCount").type(JsonFieldType.NUMBER)
                             .description("좋아요 개수"),
-                        fieldWithPath("contents.[].viewCount").type(JsonFieldType.NUMBER)
+                        fieldWithPath("getContentsCommonResponse.contents.[].viewCount").type(JsonFieldType.NUMBER)
                             .description("조회수 개수"),
-                        fieldWithPath("contents.[].isBookmarked").type(JsonFieldType.BOOLEAN)
+                        fieldWithPath("getContentsCommonResponse.contents.[].isBookmarked").type(JsonFieldType.BOOLEAN)
                             .description("북마크 여부"),
-                        fieldWithPath("contents.[].isLiked").type(JsonFieldType.BOOLEAN)
+                        fieldWithPath("getContentsCommonResponse.contents.[].isLiked").type(JsonFieldType.BOOLEAN)
                             .description("좋아요 여부"),
-                        fieldWithPath("contents.[].createdAt").type(JsonFieldType.STRING)
+                        fieldWithPath("getContentsCommonResponse.contents.[].createdAt").type(JsonFieldType.STRING)
                             .description("컨텐츠 생성 날짜"),
-                        fieldWithPath("contents.[].recommendationCompanies").type(
+                        fieldWithPath("getContentsCommonResponse.contents.[].recommendationCompanies").type(
                             JsonFieldType.ARRAY).description("회사 추천 배열"),
-                        fieldWithPath("contents.[].recommendationCompanies.[].companyName").type(
+                        fieldWithPath("getContentsCommonResponse.contents.[].recommendationCompanies.[].companyName").type(
                             JsonFieldType.STRING).description("회사명"),
                         fieldWithPath(
-                            "contents.[].recommendationCompanies.[].companyLogoImgUrl").type(
+                            "getContentsCommonResponse.contents.[].recommendationCompanies.[].companyLogoImgUrl").type(
                             JsonFieldType.STRING).description("회사 로고 URL"),
-                        fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN)
+                        fieldWithPath("getContentsCommonResponse.hasNext").type(JsonFieldType.BOOLEAN)
                             .description("다음 페이지 존재여부"),
                         fieldWithPath("keyword").type(JsonFieldType.STRING).description("검색 키워드"),
                         fieldWithPath("resultCount").type(JsonFieldType.NUMBER)

--- a/src/test/java/com/hyperlink/server/content/controller/ContentControllerTest.java
+++ b/src/test/java/com/hyperlink/server/content/controller/ContentControllerTest.java
@@ -72,7 +72,7 @@ public class ContentControllerTest extends AuthSetupForMock {
       void addInquiryOfContentTest() throws Exception {
         mockMvc.perform(
                 patch("/contents/" + contentId + "/view")
-                //                    .header("AccessToken", accessToken)
+                .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
             )
             .andExpect(status().isOk())
             .andDo(
@@ -81,8 +81,7 @@ public class ContentControllerTest extends AuthSetupForMock {
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
                     requestHeaders(
-                        // TODO : jwt
-//                        headerWithName("AccessToken").description("jwt header")
+                        headerWithName(HttpHeaders.AUTHORIZATION).description("jwt header")
                     ),
                     responseFields(
                         fieldWithPath("viewCount").type(JsonFieldType.NUMBER)

--- a/src/test/java/com/hyperlink/server/creator/controller/CreatorControllerTest.java
+++ b/src/test/java/com/hyperlink/server/creator/controller/CreatorControllerTest.java
@@ -3,6 +3,7 @@ package com.hyperlink.server.creator.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doReturn;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
@@ -13,6 +14,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hyperlink.server.AuthSetupForMock;
+import com.hyperlink.server.domain.auth.token.JwtTokenProvider;
 import com.hyperlink.server.domain.category.domain.entity.Category;
 import com.hyperlink.server.domain.creator.application.CreatorService;
 import com.hyperlink.server.domain.creator.controller.CreatorController;
@@ -31,6 +34,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -39,7 +43,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 @MockBean(JpaMetamodelMappingContext.class)
 @AutoConfigureRestDocs
 @AutoConfigureMockMvc
-public class CreatorControllerTest {
+public class CreatorControllerTest extends AuthSetupForMock {
 
   @MockBean
   CreatorService creatorService;
@@ -47,6 +51,8 @@ public class CreatorControllerTest {
   MockMvc mockMvc;
   @Autowired
   ObjectMapper objectMapper;
+  @MockBean
+  JwtTokenProvider jwtTokenProvider;
 
   @Nested
   @DisplayName("크리에이터 생성 API는")
@@ -143,6 +149,8 @@ public class CreatorControllerTest {
       @Test
       @DisplayName("해당 멤버의 비추천 크리에이터 목록에 추가하고 OK를 응답한다")
       void addNotRecommend() throws Exception {
+        authSetup();
+
         long creatorId = 10L;
         Member member = new Member("email", "nickname", "career", "careerYear", "profileImgUrl");
         Category category = new Category("개발");
@@ -153,7 +161,7 @@ public class CreatorControllerTest {
 
         mockMvc.perform(
                 post("/creators/" + creatorId + "/not-recommend")
-                    // .header("AccessToken", accessToken)
+                    .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
                     .characterEncoding("UTF-8")
             )
             .andExpect(status().isOk())
@@ -163,8 +171,7 @@ public class CreatorControllerTest {
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
                     requestHeaders(
-                        // TODO : jwt
-//                        headerWithName("AccessToken").description("jwt header")
+                        headerWithName(HttpHeaders.AUTHORIZATION).description("jwt header")
                     )
                 )
             );

--- a/src/test/java/com/hyperlink/server/memberContent/controller/MemberContentControllerTest.java
+++ b/src/test/java/com/hyperlink/server/memberContent/controller/MemberContentControllerTest.java
@@ -1,5 +1,6 @@
 package com.hyperlink.server.memberContent.controller;
 
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -8,6 +9,8 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.hyperlink.server.AuthSetupForMock;
+import com.hyperlink.server.domain.auth.token.JwtTokenProvider;
 import com.hyperlink.server.domain.memberContent.application.MemberContentService;
 import com.hyperlink.server.domain.memberContent.controller.MemberContentController;
 import org.junit.jupiter.api.Assertions;
@@ -20,6 +23,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
@@ -27,12 +31,14 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 @MockBean(JpaMetamodelMappingContext.class)
 @AutoConfigureRestDocs
 @AutoConfigureMockMvc
-public class MemberContentControllerTest {
+public class MemberContentControllerTest extends AuthSetupForMock {
 
   @MockBean
   MemberContentService memberContentService;
   @Autowired
   MockMvc mockMvc;
+  @MockBean
+  JwtTokenProvider jwtTokenProvider;
 
   @Nested
   @DisplayName("북마크 추가/삭제 API는")
@@ -49,6 +55,7 @@ public class MemberContentControllerTest {
       void failRequestTest() throws Exception {
         mockMvc.perform(
                 post("/bookmark/" + contentId + "?type=")
+                    .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
             )
             .andExpect(status().isBadRequest())
             .andExpect(response -> Assertions.assertTrue(
@@ -63,8 +70,11 @@ public class MemberContentControllerTest {
       @Test
       @DisplayName("북마크 삭제에 성공하고 OK를 응답한다")
       void deleteBookmarkTest() throws Exception {
+        authSetup();
+
         mockMvc.perform(
                 post("/bookmark/" + contentId)
+                    .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
                     .param("type", "0")
             )
             .andExpect(status().isOk())
@@ -74,8 +84,7 @@ public class MemberContentControllerTest {
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
                     requestHeaders(
-                        // TODO : jwt
-//                        headerWithName("AccessToken").description("jwt header")
+                        headerWithName(HttpHeaders.AUTHORIZATION).description("jwt header")
                     )
                 )
             );
@@ -84,9 +93,12 @@ public class MemberContentControllerTest {
       @Test
       @DisplayName("북마크 추가에 성공하고 OK를 응답한다")
       void createBookmarkTest() throws Exception {
+        authSetup();
+        
         mockMvc.perform(
                 post("/bookmark/" + contentId)
                     .param("type", "1")
+                    .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
             )
             .andExpect(status().isOk())
             .andDo(
@@ -95,8 +107,7 @@ public class MemberContentControllerTest {
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
                     requestHeaders(
-                        // TODO : jwt
-//                        headerWithName("AccessToken").description("jwt header")
+                        headerWithName(HttpHeaders.AUTHORIZATION).description("jwt header")
                     )
                 )
             );


### PR DESCRIPTION
### 변경 내용 요약
- 기존 개발 완료된 API에 jwt 헤더 추가
- 검색 API 최신순 정렬 오류 수정

### 작업한 내용
- 기존 개발 완료된 API에 jwt 헤더 추가
- 검색 API 최신순 정렬 오류 수정

close #80 
