### PR TITLE
[#137] 크리에이터 구독 추가/삭제 기능 구현

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -51,6 +51,10 @@ operation::MemberHistoryControllerTest/getAllHistory[snippets='http-request,http
 
 operation::CreatorControllerTest/notRecommend[snippets='http-request,http-response']
 
+== Subscription
+=== 크리에이터 구독/구독 취소
+operation::SubscriptionControllerTest/subscribeOrUnsubscribeCreator[snippets='http-request,http-response']
+
 == Admin
 === 크리에이터 삭제
 operation::CreatorControllerTest/deleteCreator[snippets='http-request,http-response']

--- a/src/main/java/com/hyperlink/server/domain/creator/controller/CreatorController.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/controller/CreatorController.java
@@ -36,6 +36,7 @@ public class CreatorController {
   @ResponseStatus(HttpStatus.OK)
   public void deleteCreator(@LoginMemberId Optional<Long> memberId,
       @PathVariable("creatorId") Long creatorId) {
+    memberId.orElseThrow(TokenNotExistsException::new);
     creatorService.deleteCreator(creatorId);
   }
 

--- a/src/main/java/com/hyperlink/server/domain/subscription/application/SubscriptionService.java
+++ b/src/main/java/com/hyperlink/server/domain/subscription/application/SubscriptionService.java
@@ -34,11 +34,9 @@ public class SubscriptionService {
     boolean exist = subscriptionRepository.existsByMemberIdAndCreatorId(member.getId(),
         creator.getId());
     if(exist) {
-      // 구독 취소하기
       subscriptionRepository.deleteByMemberIdAndCreatorId(member.getId(), creator.getId());
       return SubscribeResponse.of(false);
     }
-    // 구독하기
     subscriptionRepository.save(new Subscription(member, creator));
     return SubscribeResponse.of(true);
   }

--- a/src/main/java/com/hyperlink/server/domain/subscription/application/SubscriptionService.java
+++ b/src/main/java/com/hyperlink/server/domain/subscription/application/SubscriptionService.java
@@ -1,0 +1,45 @@
+package com.hyperlink.server.domain.subscription.application;
+
+import com.hyperlink.server.domain.creator.domain.CreatorRepository;
+import com.hyperlink.server.domain.creator.domain.entity.Creator;
+import com.hyperlink.server.domain.creator.exception.CreatorNotFoundException;
+import com.hyperlink.server.domain.member.domain.MemberRepository;
+import com.hyperlink.server.domain.member.domain.entity.Member;
+import com.hyperlink.server.domain.member.exception.MemberNotFoundException;
+import com.hyperlink.server.domain.subscription.domain.SubscriptionRepository;
+import com.hyperlink.server.domain.subscription.domain.entity.Subscription;
+import com.hyperlink.server.domain.subscription.dto.SubscribeResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SubscriptionService {
+
+  private final SubscriptionRepository subscriptionRepository;
+  private final MemberRepository memberRepository;
+  private final CreatorRepository creatorRepository;
+
+
+  public SubscribeResponse subscribeOrUnsubscribeCreator(Long loginMemberId, Long creatorId) {
+    Member member = memberRepository.findById(loginMemberId)
+        .orElseThrow(MemberNotFoundException::new);
+    Creator creator = creatorRepository.findById(creatorId)
+        .orElseThrow(CreatorNotFoundException::new);
+
+    return subscribeOrUnsubscribeByCondition(member, creator);
+  }
+
+  private SubscribeResponse subscribeOrUnsubscribeByCondition(Member member, Creator creator) {
+    boolean exist = subscriptionRepository.existsByMemberIdAndCreatorId(member.getId(),
+        creator.getId());
+    if(exist) {
+      // 구독 취소하기
+      subscriptionRepository.deleteByMemberIdAndCreatorId(member.getId(), creator.getId());
+      return SubscribeResponse.of(false);
+    }
+    // 구독하기
+    subscriptionRepository.save(new Subscription(member, creator));
+    return SubscribeResponse.of(true);
+  }
+}

--- a/src/main/java/com/hyperlink/server/domain/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/hyperlink/server/domain/subscription/controller/SubscriptionController.java
@@ -1,0 +1,30 @@
+package com.hyperlink.server.domain.subscription.controller;
+
+import com.hyperlink.server.domain.auth.token.exception.TokenNotExistsException;
+import com.hyperlink.server.domain.subscription.dto.SubscribeResponse;
+import com.hyperlink.server.domain.subscription.application.SubscriptionService;
+import com.hyperlink.server.global.config.LoginMemberId;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class SubscriptionController {
+
+  private final SubscriptionService subscriptionService;
+
+  @PostMapping("/creators/{creatorId}/subscribe")
+  @ResponseStatus(HttpStatus.OK)
+  public SubscribeResponse subscribeOrUnsubscribeCreator(@LoginMemberId Optional<Long> memberId,
+      @PathVariable("creatorId") Long creatorId) {
+    Long loginMemberId = memberId.orElseThrow(TokenNotExistsException::new);
+    return subscriptionService.subscribeOrUnsubscribeCreator(loginMemberId, creatorId);
+  }
+
+
+}

--- a/src/main/java/com/hyperlink/server/domain/subscription/domain/SubscriptionRepository.java
+++ b/src/main/java/com/hyperlink/server/domain/subscription/domain/SubscriptionRepository.java
@@ -1,8 +1,11 @@
 package com.hyperlink.server.domain.subscription.domain;
 
 import com.hyperlink.server.domain.subscription.domain.entity.Subscription;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
 
+  boolean existsByMemberIdAndCreatorId(Long memberId, Long creatorId);
+  void deleteByMemberIdAndCreatorId(Long memberId, Long creatorId);
 }

--- a/src/main/java/com/hyperlink/server/domain/subscription/domain/entity/Subscription.java
+++ b/src/main/java/com/hyperlink/server/domain/subscription/domain/entity/Subscription.java
@@ -32,4 +32,9 @@ public class Subscription extends BaseEntity {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "creator_id")
   private Creator creator;
+
+  public Subscription(Member member, Creator creator) {
+    this.member = member;
+    this.creator = creator;
+  }
 }

--- a/src/main/java/com/hyperlink/server/domain/subscription/dto/SubscribeResponse.java
+++ b/src/main/java/com/hyperlink/server/domain/subscription/dto/SubscribeResponse.java
@@ -1,0 +1,8 @@
+package com.hyperlink.server.domain.subscription.dto;
+
+public record SubscribeResponse(Boolean isSubscribed) {
+
+  public static SubscribeResponse of(boolean isSubscribed) {
+    return new SubscribeResponse(isSubscribed);
+  }
+}

--- a/src/test/java/com/hyperlink/server/subscription/application/SubscriptionServiceIntegrationTest.java
+++ b/src/test/java/com/hyperlink/server/subscription/application/SubscriptionServiceIntegrationTest.java
@@ -1,0 +1,134 @@
+package com.hyperlink.server.subscription.application;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hyperlink.server.domain.category.domain.CategoryRepository;
+import com.hyperlink.server.domain.category.domain.entity.Category;
+import com.hyperlink.server.domain.creator.domain.CreatorRepository;
+import com.hyperlink.server.domain.creator.domain.entity.Creator;
+import com.hyperlink.server.domain.creator.exception.CreatorNotFoundException;
+import com.hyperlink.server.domain.member.domain.Career;
+import com.hyperlink.server.domain.member.domain.CareerYear;
+import com.hyperlink.server.domain.member.domain.MemberRepository;
+import com.hyperlink.server.domain.member.domain.entity.Member;
+import com.hyperlink.server.domain.member.exception.MemberNotFoundException;
+import com.hyperlink.server.domain.subscription.application.SubscriptionService;
+import com.hyperlink.server.domain.subscription.dto.SubscribeResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@DisplayName("구독 서비스 통합 테스트")
+public class SubscriptionServiceIntegrationTest {
+
+  @Autowired
+  SubscriptionService subscriptionService;
+  @Autowired
+  CategoryRepository categoryRepository;
+  @Autowired
+  CreatorRepository creatorRepository;
+  @Autowired
+  MemberRepository memberRepository;
+
+
+  @Nested
+  @DisplayName("크리에이터 구독 테스트는")
+  class SubscribeTest {
+
+    @Nested
+    @DisplayName("[성공]")
+    class Success {
+
+      Member member;
+      Creator creator;
+
+      @BeforeEach
+      void setUp() {
+        Category developCategory = new Category("개발");
+        categoryRepository.save(developCategory);
+        creator = new Creator("개발좋아하는사람", "profileImgUrl", "description", developCategory);
+        creatorRepository.save(creator);
+
+        member = new Member("email", "nickname", Career.DEVELOP, CareerYear.EIGHT,
+            "profileImgUrl");
+        memberRepository.save(member);
+      }
+
+      @Test
+      @DisplayName("해당 크리에이터를 구독하지 않은 경우 구독한다.")
+      void subscribeCreatorTest() throws Exception {
+        Member foundMember = memberRepository.findById(member.getId()).get();
+        Creator foundCreator = creatorRepository.findById(creator.getId()).get();
+
+        SubscribeResponse subscribeResponse = subscriptionService.subscribeOrUnsubscribeCreator(
+            foundMember.getId(),
+            foundCreator.getId());
+
+        assertTrue(subscribeResponse.isSubscribed());
+      }
+
+      @Test
+      @DisplayName("해당 크리에이터를 구독한 경우 구독을 취소한다.")
+      void unsubscribeCreatorTest() throws Exception {
+        Member foundMember = memberRepository.findById(member.getId()).get();
+        Creator foundCreator = creatorRepository.findById(creator.getId()).get();
+        subscriptionService.subscribeOrUnsubscribeCreator(foundMember.getId(),
+            foundCreator.getId());
+
+        SubscribeResponse subscribeResponse = subscriptionService.subscribeOrUnsubscribeCreator(
+            foundMember.getId(),
+            foundCreator.getId());
+
+        assertFalse(subscribeResponse.isSubscribed());
+      }
+    }
+
+    @Nested
+    @DisplayName("[실패]")
+    class Fail {
+      Member member;
+      Creator creator;
+
+      @BeforeEach
+      void setUp() {
+        Category developCategory = new Category("개발");
+        categoryRepository.save(developCategory);
+        creator = new Creator("개발좋아하는사람", "profileImgUrl", "description", developCategory);
+        creatorRepository.save(creator);
+
+        member = new Member("email", "nickname", Career.DEVELOP, CareerYear.EIGHT,
+            "profileImgUrl");
+        memberRepository.save(member);
+      }
+
+      @Test
+      @DisplayName("해당 멤버 id가 잘못된 경우 MemberNotFoundException 이 발생한다.")
+      void failWithMemberNotFoundException() {
+        Long memberId = -1L;
+
+        Assertions.assertThrows(MemberNotFoundException.class,
+            () -> subscriptionService.subscribeOrUnsubscribeCreator(memberId, creator.getId()));
+      }
+
+      @Test
+      @DisplayName("해당 크리에이터 id가 잘못된 경우 CreatorNotFoundException 이 발생한다.")
+      void failWithCreatorNotFoundException() {
+        Long creatorId = -1L;
+
+        Assertions.assertThrows(CreatorNotFoundException.class,
+            () -> subscriptionService.subscribeOrUnsubscribeCreator(member.getId(), creatorId));
+      }
+    }
+
+  }
+
+
+}

--- a/src/test/java/com/hyperlink/server/subscription/application/SubscriptionServiceMockTest.java
+++ b/src/test/java/com/hyperlink/server/subscription/application/SubscriptionServiceMockTest.java
@@ -1,0 +1,93 @@
+package com.hyperlink.server.subscription.application;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.hyperlink.server.domain.category.domain.entity.Category;
+import com.hyperlink.server.domain.creator.domain.CreatorRepository;
+import com.hyperlink.server.domain.creator.domain.entity.Creator;
+import com.hyperlink.server.domain.creator.exception.CreatorNotFoundException;
+import com.hyperlink.server.domain.member.domain.Career;
+import com.hyperlink.server.domain.member.domain.CareerYear;
+import com.hyperlink.server.domain.member.domain.MemberRepository;
+import com.hyperlink.server.domain.member.domain.entity.Member;
+import com.hyperlink.server.domain.member.exception.MemberNotFoundException;
+import com.hyperlink.server.domain.subscription.application.SubscriptionService;
+import com.hyperlink.server.domain.subscription.domain.SubscriptionRepository;
+import com.hyperlink.server.domain.subscription.dto.SubscribeResponse;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("구독 서비스 Mock 테스트")
+public class SubscriptionServiceMockTest {
+
+  @Mock
+  SubscriptionRepository subscriptionRepository;
+  @Mock
+  MemberRepository memberRepository;
+  @Mock
+  CreatorRepository creatorRepository;
+
+  @InjectMocks
+  SubscriptionService subscriptionService;
+
+
+  @Nested
+  @DisplayName("크리에이터 구독 테스트는")
+  class SubscribeTest {
+
+    @Nested
+    @DisplayName("[성공]")
+    class Success {
+
+      Member member = new Member("email", "nickname", Career.DEVELOP, CareerYear.EIGHT,
+          "profileImgUrl");
+      Category category = new Category("개발");
+      Creator creator = new Creator("개발자", "profileImgUrl", "description", category);
+
+      @Test
+      @DisplayName("해당 크리에이터를 구독하지 않은 경우 구독한다.")
+      void subscribeCreatorTest() throws Exception {
+        when(subscriptionRepository.existsByMemberIdAndCreatorId(any(), any())).thenReturn(false);
+        when(memberRepository.findById(any())).thenReturn(Optional.of(member));
+        when(creatorRepository.findById(any())).thenReturn(Optional.of(creator));
+
+        SubscribeResponse subscribeResponse = subscriptionService.subscribeOrUnsubscribeCreator(
+            1L, 1L);
+
+        assertTrue(subscribeResponse.isSubscribed());
+        verify(subscriptionRepository, times(0)).deleteByMemberIdAndCreatorId(any(), any());
+        verify(subscriptionRepository, times(1)).save(any());
+      }
+
+      @Test
+      @DisplayName("해당 크리에이터를 구독한 경우 구독을 취소한다.")
+      void unsubscribeCreatorTest() throws Exception {
+        when(subscriptionRepository.existsByMemberIdAndCreatorId(any(), any())).thenReturn(true);
+        when(memberRepository.findById(any())).thenReturn(Optional.of(member));
+        when(creatorRepository.findById(any())).thenReturn(Optional.of(creator));
+
+        SubscribeResponse subscribeResponse = subscriptionService.subscribeOrUnsubscribeCreator(
+            1L, 1L);
+
+        assertFalse(subscribeResponse.isSubscribed());
+        verify(subscriptionRepository, times(1)).deleteByMemberIdAndCreatorId(any(), any());
+        verify(subscriptionRepository, times(0)).save(any());
+      }
+    }
+  }
+
+}

--- a/src/test/java/com/hyperlink/server/subscription/controller/SubscriptionControllerTest.java
+++ b/src/test/java/com/hyperlink/server/subscription/controller/SubscriptionControllerTest.java
@@ -170,17 +170,6 @@ public class SubscriptionControllerTest extends AuthSetupForMock {
         }
       }
 
-      @Nested
-      @DisplayName("로그인 하지 않은")
-      class IfNotLogin {
-
-        @Test
-        @DisplayName("사용자가 구독 버튼을 누르면 401 UnAuthorized 를 반환한다.")
-        void unAuthorized() {
-
-        }
-      }
-
 
     }
   }

--- a/src/test/java/com/hyperlink/server/subscription/controller/SubscriptionControllerTest.java
+++ b/src/test/java/com/hyperlink/server/subscription/controller/SubscriptionControllerTest.java
@@ -1,0 +1,188 @@
+package com.hyperlink.server.subscription.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hyperlink.server.AuthSetupForMock;
+import com.hyperlink.server.domain.creator.exception.CreatorNotFoundException;
+import com.hyperlink.server.domain.member.exception.MemberNotFoundException;
+import com.hyperlink.server.domain.subscription.application.SubscriptionService;
+import com.hyperlink.server.domain.subscription.controller.SubscriptionController;
+import com.hyperlink.server.domain.subscription.dto.SubscribeResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(SubscriptionController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc
+public class SubscriptionControllerTest extends AuthSetupForMock {
+
+  @MockBean
+  SubscriptionService subscriptionService;
+
+  @Autowired
+  MockMvc mockMvc;
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @Nested
+  @DisplayName("크리에이터 구독 추가/삭제 API는")
+  class SubscribeCreatorTest {
+
+    @Nested
+    @DisplayName("[성공]")
+    class Success {
+
+      @Nested
+      @DisplayName("로그인 한")
+      class IfLogin {
+
+        @BeforeEach
+        void setUp() {
+          authSetup();
+        }
+
+        @Test
+        @DisplayName("사용자가 크리에이터를 이미 구독한 상황이었다면 구독 취소하고 200 OK와 구독 상태를 반환한다.")
+        void unsubscribeIfSubscribed() throws Exception {
+          Long loginMemberId = 1L;
+          Long creatorId = 1L;
+
+          SubscribeResponse subscribeResponse = new SubscribeResponse(false);
+          given(subscriptionService.subscribeOrUnsubscribeCreator(loginMemberId, creatorId))
+              .willReturn(subscribeResponse);
+
+          mockMvc.perform(
+                  post("/creators/" + creatorId + "/subscribe")
+                      .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                      .characterEncoding("UTF-8"))
+              .andExpect(status().isOk())
+              .andDo(print())
+              .andDo(document("SubscriptionControllerTest/subscribeOrUnsubscribeCreator",
+                  preprocessRequest(prettyPrint()),
+                  preprocessResponse(prettyPrint()),
+                  requestHeaders(
+                      headerWithName(HttpHeaders.AUTHORIZATION).description("AccessToken")
+                  ),
+                  responseFields(
+                      fieldWithPath("isSubscribed").type(JsonFieldType.BOOLEAN)
+                          .description("구독 여부 상태")
+                  )
+              ));
+        }
+
+        @Test
+        @DisplayName("사용자가 크리에이터를 구독하지 않은 상황이었다면 구독하고 200 OK와 구독 상태를 반환한다.")
+        void subscribeIfUnsubscribed() throws Exception {
+          Long loginMemberId = 1L;
+          Long creatorId = 1L;
+
+          SubscribeResponse subscribeResponse = new SubscribeResponse(true);
+          when(subscriptionService.subscribeOrUnsubscribeCreator(loginMemberId, creatorId))
+              .thenReturn(subscribeResponse);
+
+          mockMvc.perform(post("/creators/" + creatorId + "/subscribe")
+                  .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                  .contentType(MediaType.APPLICATION_JSON))
+              .andExpect(status().isOk())
+              .andDo(print());
+        }
+      }
+    }
+
+
+    @Nested
+    @DisplayName("[실패]")
+    class Fail {
+
+      @Nested
+      @DisplayName("잘못된")
+      class IfLogin {
+
+        @BeforeEach
+        void setUp() {
+          authSetup();
+        }
+
+        @Test
+        @DisplayName("사용자가 크리에이터를 크리에이터에 대해 구독버튼을 누르면 404 NOT FOUND 를  반환한다.")
+        void throwsMemberNotFoundException() throws Exception {
+          Long wrongMemberId = 1L;
+          Long creatorId = 1L;
+
+          when(subscriptionService.subscribeOrUnsubscribeCreator(wrongMemberId, creatorId))
+              .thenThrow(new MemberNotFoundException());
+
+          mockMvc.perform(
+                  post("/creators/" + creatorId + "/subscribe")
+                      .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                      .characterEncoding("UTF-8"))
+              .andExpect(status().isNotFound())
+              .andDo(print())
+              .andExpect(response -> Assertions.assertTrue(
+                      response.getResolvedException() instanceof MemberNotFoundException));
+        }
+
+        @Test
+        @DisplayName("크리에이터에 대해 구독버튼을 누르면 404 NOT FOUND 를 반환한다.")
+        void throwsCreatorNotFoundException() throws Exception {
+          Long loginMemberId = 1L;
+          Long wrongCreatorId = 1L;
+
+          when(subscriptionService.subscribeOrUnsubscribeCreator(loginMemberId, wrongCreatorId))
+              .thenThrow(new CreatorNotFoundException());
+
+          mockMvc.perform(
+                  post("/creators/" + wrongCreatorId + "/subscribe")
+                      .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                      .characterEncoding("UTF-8"))
+              .andExpect(status().isNotFound())
+              .andDo(print())
+              .andExpect(response -> Assertions.assertTrue(
+                  response.getResolvedException() instanceof CreatorNotFoundException));
+        }
+      }
+
+      @Nested
+      @DisplayName("로그인 하지 않은")
+      class IfNotLogin {
+
+        @Test
+        @DisplayName("사용자가 구독 버튼을 누르면 401 UnAuthorized 를 반환한다.")
+        void unAuthorized() {
+
+        }
+      }
+
+
+    }
+  }
+
+}


### PR DESCRIPTION
### 변경 내용 요약
- 크리에이터 구독 추가/삭제 기능 구현

### 작업한 내용
- 크리에이터 구독 추가/삭제 기능 구현 및 테스트 코드를 작성했습니다.
- 코드 작업 중간에 AuthSetup 부분이 변경되어서 그에 맞게 다시 변경하여 테스트 코드 작성했습니다.
  - JwtTokenProvider가 AuthSetUp 클래스 외부에 있었는데 내부로 이동한 것이 확인되어 그에 맞게 테스트 코드에서는 JwtTokenProvider를 제거해주었습니다.
- CreatorController에서 MockMvc를 사용한 Exception 발생 테스트 코드를 작성했습니다. 지난 #114 PR에서 다루었던 문제를 해결합니다.

close #137
