### PR TITLE
[#143] 메인 페이지에 보일 컨텐츠 전체보기 기능 구현

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -17,6 +17,10 @@ operation::ContentControllerTest/addInquiryOfContent[snippets='http-request,http
 
 operation::ContentControllerTest/search[snippets='http-request,http-response,response-fields']
 
+=== 조회
+
+operation::ContentControllerTest/retrieve[snippets="http-request,http-response"]
+
 == MemberContent
 
 === 북마크 추가/삭제

--- a/src/main/java/com/hyperlink/server/domain/attentionCategory/domain/AttentionCategoryRepository.java
+++ b/src/main/java/com/hyperlink/server/domain/attentionCategory/domain/AttentionCategoryRepository.java
@@ -1,8 +1,12 @@
 package com.hyperlink.server.domain.attentionCategory.domain;
 
 import com.hyperlink.server.domain.attentionCategory.domain.entity.AttentionCategory;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface AttentionCategoryRepository extends JpaRepository<AttentionCategory, Long> {
 
+  @Query("select at.category.id from AttentionCategory at where at.member.id = :memberId")
+  List<Long> findAttentionCategoryIdsByMemberId(Long memberId);
 }

--- a/src/main/java/com/hyperlink/server/domain/category/domain/CategoryRepository.java
+++ b/src/main/java/com/hyperlink/server/domain/category/domain/CategoryRepository.java
@@ -1,9 +1,14 @@
 package com.hyperlink.server.domain.category.domain;
 
 import com.hyperlink.server.domain.category.domain.entity.Category;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
   Optional<Category> findByName(String name);
+
+  @Query("select c.id from Category c")
+  List<Long> findAllCategoryIds();
 }

--- a/src/main/java/com/hyperlink/server/domain/common/ContentDtoFactoryService.java
+++ b/src/main/java/com/hyperlink/server/domain/common/ContentDtoFactoryService.java
@@ -16,13 +16,13 @@ public class ContentDtoFactoryService {
 
   private final MemberContentService memberContentService;
 
+  /**
+   * @description memberId에 null이 들어올 수 있음 null이라면 isBookmarked에서 false 반환
+   */
   public GetContentsCommonResponse createContentResponses(Long memberId, List<Content> contents,
       boolean hasNext) {
     List<ContentResponse> contentResponses = new ArrayList<>();
     for (Content content : contents) {
-      /**
-       * @description memberId에 null이 들어올 수 있음 null이라면 isBookmarked에서 false 반환
-       */
       boolean isBookmarked = memberContentService.isBookmarked(memberId, content.getId());
       boolean isLiked = content.getLikeCount() > 0;
       // TODO : 회사 추천 리스트 추가

--- a/src/main/java/com/hyperlink/server/domain/common/ContentDtoFactoryService.java
+++ b/src/main/java/com/hyperlink/server/domain/common/ContentDtoFactoryService.java
@@ -20,6 +20,9 @@ public class ContentDtoFactoryService {
       boolean hasNext) {
     List<ContentResponse> contentResponses = new ArrayList<>();
     for (Content content : contents) {
+      /**
+       * @description memberId에 null이 들어올 수 있음 null이라면 isBookmarked에서 false 반환
+       */
       boolean isBookmarked = memberContentService.isBookmarked(memberId, content.getId());
       boolean isLiked = content.getLikeCount() > 0;
       // TODO : 회사 추천 리스트 추가

--- a/src/main/java/com/hyperlink/server/domain/content/application/ContentService.java
+++ b/src/main/java/com/hyperlink/server/domain/content/application/ContentService.java
@@ -85,4 +85,11 @@ public class ContentService {
     contentRepository.save(content);
     return content.getId();
   }
+
+  @Transactional
+  public void activateContent(Long contentId) {
+    Content content = contentRepository.findById(contentId)
+        .orElseThrow(ContentNotFoundException::new);
+    content.makeViewable(true);
+  }
 }

--- a/src/main/java/com/hyperlink/server/domain/content/controller/ContentController.java
+++ b/src/main/java/com/hyperlink/server/domain/content/controller/ContentController.java
@@ -78,6 +78,17 @@ public class ContentController {
         PageRequest.of(page, size));
   }
 
+  @GetMapping("/contents/all")
+  @ResponseStatus(HttpStatus.OK)
+  public GetContentsCommonResponse getAllCategoriesContents(@LoginMemberId Optional<Long> optionalMemberId,
+      @RequestParam("page") @NotNull int page,
+      @RequestParam("size") @NotNull int size,
+      @RequestParam("sort") @NotBlank String sort) {
+    Long memberId = optionalMemberId.orElse(null);
+    return contentService.retrieveTrendAllCategoriesContents(
+        memberId, sort, PageRequest.of(page, size));
+  }
+
   @PostMapping("/admin/contents/{contentId}/activate")
   @ResponseStatus(HttpStatus.OK)
   public void activateContent(@LoginMemberId Optional<Long> optionalMemberId,

--- a/src/main/java/com/hyperlink/server/domain/content/controller/ContentController.java
+++ b/src/main/java/com/hyperlink/server/domain/content/controller/ContentController.java
@@ -4,6 +4,7 @@ import com.hyperlink.server.domain.auth.token.exception.TokenNotExistsException;
 import com.hyperlink.server.domain.content.application.ContentService;
 import com.hyperlink.server.domain.content.dto.PatchInquiryResponse;
 import com.hyperlink.server.domain.content.dto.SearchResponse;
+import com.hyperlink.server.domain.member.exception.MemberNotFoundException;
 import com.hyperlink.server.global.config.LoginMemberId;
 import java.util.Optional;
 import javax.validation.constraints.NotBlank;
@@ -17,6 +18,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -25,12 +27,11 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/contents")
 public class ContentController {
 
   private final ContentService contentService;
 
-  @PatchMapping("/{contentId}/view")
+  @PatchMapping("/contents/{contentId}/view")
   @ResponseStatus(HttpStatus.OK)
   public PatchInquiryResponse addViewOfContent(@PathVariable("contentId") long contentId) {
     // TODO : JWT
@@ -40,7 +41,7 @@ public class ContentController {
     return new PatchInquiryResponse(viewCount);
   }
 
-  @GetMapping("/search")
+  @PostMapping("/contents/search")
   @ResponseStatus(HttpStatus.OK)
   public SearchResponse search(@LoginMemberId Optional<Long> memberId,
       @RequestParam("keyword") @NotBlank String keyword,
@@ -53,4 +54,11 @@ public class ContentController {
     return contentService.search(memberId.get(), keyword, pageable);
   }
 
+  @PostMapping("/admin/contents/{contentId}/activate")
+  @ResponseStatus(HttpStatus.OK)
+  public void activateContent(@LoginMemberId Optional<Long> optionalMemberId,
+      @PathVariable("contentId") Long contentId) {
+    Long memberId = optionalMemberId.orElseThrow(MemberNotFoundException::new);
+    contentService.activateContent(contentId);
+  }
 }

--- a/src/main/java/com/hyperlink/server/domain/content/domain/entity/Content.java
+++ b/src/main/java/com/hyperlink/server/domain/content/domain/entity/Content.java
@@ -62,4 +62,8 @@ public class Content extends BaseEntity {
     this.creator = creator;
     this.category = category;
   }
+
+  public void makeViewable(boolean check) {
+    this.isViewable = check;
+  }
 }

--- a/src/main/java/com/hyperlink/server/domain/content/dto/ContentResponse.java
+++ b/src/main/java/com/hyperlink/server/domain/content/dto/ContentResponse.java
@@ -14,7 +14,7 @@ public record ContentResponse(
     boolean isBookmarked,
     boolean isLiked,
     String createdAt,
-    List<RecommendationCompanyResponse> recommendationCompanies
+    List<RecommendationCompanyResponse> recommendations
 ) {
 
 }

--- a/src/main/java/com/hyperlink/server/domain/content/dto/RecommendationCompanyResponse.java
+++ b/src/main/java/com/hyperlink/server/domain/content/dto/RecommendationCompanyResponse.java
@@ -1,8 +1,8 @@
 package com.hyperlink.server.domain.content.dto;
 
 public record RecommendationCompanyResponse(
-    String companyName,
-    String companyLogoImgUrl
+    String bannerName,
+    String bannerLogoImgUrl
 ) {
 
 }

--- a/src/main/java/com/hyperlink/server/domain/content/exception/CategoryAndCreatorIdConstraintViolationException.java
+++ b/src/main/java/com/hyperlink/server/domain/content/exception/CategoryAndCreatorIdConstraintViolationException.java
@@ -1,0 +1,14 @@
+package com.hyperlink.server.domain.content.exception;
+
+import com.hyperlink.server.global.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class CategoryAndCreatorIdConstraintViolationException extends BusinessException {
+
+  private static final String MESSAGE = "카테고리와 크리에이터 id의 입력조건이 잘못되었습니다.";
+  private static final HttpStatus status = HttpStatus.BAD_REQUEST;
+
+  public CategoryAndCreatorIdConstraintViolationException() {
+    super(MESSAGE, status);
+  }
+}

--- a/src/main/java/com/hyperlink/server/domain/content/exception/InvalidSortException.java
+++ b/src/main/java/com/hyperlink/server/domain/content/exception/InvalidSortException.java
@@ -1,0 +1,15 @@
+package com.hyperlink.server.domain.content.exception;
+
+import com.hyperlink.server.global.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidSortException extends BusinessException {
+
+  private static final String MESSAGE = "올바르지 않은 정렬 옵션입니다.";
+  private static final HttpStatus status = HttpStatus.BAD_REQUEST;
+
+
+  public InvalidSortException() {
+    super(MESSAGE, status);
+  }
+}

--- a/src/main/java/com/hyperlink/server/domain/content/infrastructure/ContentRepositoryCustom.java
+++ b/src/main/java/com/hyperlink/server/domain/content/infrastructure/ContentRepositoryCustom.java
@@ -74,7 +74,7 @@ public class ContentRepositoryCustom {
   public Slice<Content> retrievePopularContentsByCreator(Long creatorId, Pageable pageable) {
     List<Content> contents = queryFactory
         .selectFrom(content)
-        .where(content.creator.id.eq(creatorId))
+        .where(eqCreatorId(creatorId))
         .orderBy(popularOrderType())
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize() + 1)
@@ -86,7 +86,7 @@ public class ContentRepositoryCustom {
   public Slice<Content> retrieveRecentContentsByCreator(Long creatorId, Pageable pageable) {
     List<Content> contents = queryFactory
         .selectFrom(content)
-        .where(content.creator.id.eq(creatorId))
+        .where(eqCreatorId(creatorId))
         .orderBy(recentOrderType())
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize() + 1)
@@ -111,6 +111,10 @@ public class ContentRepositoryCustom {
 
   private OrderSpecifier<LocalDateTime> recentOrderType() {
     return content.createdAt.desc();
+  }
+
+  private BooleanExpression eqCreatorId(Long creatorId) {
+    return content.creator.id.eq(creatorId);
   }
 
   private BooleanExpression eqCategoryId(Long categoryId) {

--- a/src/main/java/com/hyperlink/server/domain/content/infrastructure/ContentRepositoryCustom.java
+++ b/src/main/java/com/hyperlink/server/domain/content/infrastructure/ContentRepositoryCustom.java
@@ -4,17 +4,26 @@ import static com.hyperlink.server.domain.content.domain.entity.QContent.content
 
 import com.hyperlink.server.domain.content.domain.entity.Content;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
 public class ContentRepositoryCustom {
+
+  private static final int VIEW_COUNT_WEIGHT = 1;
+  private static final int LIKE_COUNT_WEIGHT = 3;
+  private static final int PAST_DAYS = 5;
+
 
   private final JPAQueryFactory queryFactory;
 
@@ -36,5 +45,90 @@ public class ContentRepositoryCustom {
         .fetch().size();
 
     return new PageImpl<>(contents, pageable, size);
+  }
+
+  public Slice<Content> retrievePopularTrendContentsByCategory(Long categoryId, Pageable pageable) {
+    List<Content> contents = queryFactory
+        .selectFrom(content)
+        .where(eqCategoryId(categoryId), beforeNDays(PAST_DAYS))
+        .orderBy(popularOrderType())
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize() + 1)
+        .fetch();
+
+    return getSlice(pageable, contents);
+  }
+
+  public Slice<Content> retrieveRecentTrendContentsByCategory(Long categoryId, Pageable pageable) {
+    List<Content> contents = queryFactory
+        .selectFrom(content)
+        .where(eqCategoryId(categoryId))
+        .orderBy(recentOrderType())
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize() + 1)
+        .fetch();
+
+    return getSlice(pageable, contents);
+  }
+
+  public Slice<Content> retrievePopularContentsByCreator(Long creatorId, Pageable pageable) {
+    List<Content> contents = queryFactory
+        .selectFrom(content)
+        .where(content.creator.id.eq(creatorId))
+        .orderBy(popularOrderType())
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize() + 1)
+        .fetch();
+
+    return getSlice(pageable, contents);
+  }
+
+  public Slice<Content> retrieveRecentContentsByCreator(Long creatorId, Pageable pageable) {
+    List<Content> contents = queryFactory
+        .selectFrom(content)
+        .where(content.creator.id.eq(creatorId))
+        .orderBy(recentOrderType())
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize() + 1)
+        .fetch();
+
+    return getSlice(pageable, contents);
+  }
+
+  private SliceImpl<Content> getSlice(Pageable pageable, List<Content> contents) {
+    boolean hasNext = false;
+    if (contents.size() > pageable.getPageSize()) {
+      contents.remove(pageable.getPageSize());
+      hasNext = true;
+    }
+    return new SliceImpl<>(contents, pageable, hasNext);
+  }
+
+  private OrderSpecifier<Integer> popularOrderType() {
+    return content.viewCount.multiply(VIEW_COUNT_WEIGHT)
+        .add(content.likeCount.multiply(LIKE_COUNT_WEIGHT)).desc();
+  }
+
+  private OrderSpecifier<LocalDateTime> recentOrderType() {
+    return content.createdAt.desc();
+  }
+
+  private BooleanExpression eqCategoryId(Long categoryId) {
+    if (validateWhetherAllTypeOrNot(categoryId)) {
+      return null;
+    }
+    return content.category.id.eq(categoryId);
+  }
+
+  private boolean validateWhetherAllTypeOrNot(Long categoryId) {
+    if (categoryId == 0) {
+      // 전체 카테고리 id == 0
+      return true;
+    }
+    return false;
+  }
+
+  private BooleanExpression beforeNDays(long day) {
+    return content.createdAt.after(LocalDateTime.now().minusDays(day));
   }
 }

--- a/src/main/java/com/hyperlink/server/domain/content/infrastructure/ContentRepositoryCustom.java
+++ b/src/main/java/com/hyperlink/server/domain/content/infrastructure/ContentRepositoryCustom.java
@@ -71,6 +71,40 @@ public class ContentRepositoryCustom {
     return getSlice(pageable, contents);
   }
 
+  public Slice<Content> retrievePopularTrendContentsForCategories(List<Long> categoryIds, Pageable pageable) {
+    BooleanBuilder categoryConditionBuilder = new BooleanBuilder();
+    for(Long categoryId : categoryIds) {
+      categoryConditionBuilder.or(content.category.id.eq(categoryId));
+    }
+
+    List<Content> contents = queryFactory
+        .selectFrom(content)
+        .where(categoryConditionBuilder, beforeNDays(PAST_DAYS))
+        .orderBy(popularOrderType())
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize() + 1)
+        .fetch();
+
+    return getSlice(pageable, contents);
+  }
+
+  public Slice<Content> retrieveRecentTrendContentsForCategories(List<Long> categoryIds, Pageable pageable) {
+    BooleanBuilder categoryConditionBuilder = new BooleanBuilder();
+    for(Long categoryId : categoryIds) {
+      categoryConditionBuilder.or(content.category.id.eq(categoryId));
+    }
+
+    List<Content> contents = queryFactory
+        .selectFrom(content)
+        .where(categoryConditionBuilder)
+        .orderBy(recentOrderType())
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize() + 1)
+        .fetch();
+
+    return getSlice(pageable, contents);
+  }
+
   public Slice<Content> retrievePopularContentsByCreator(Long creatorId, Pageable pageable) {
     List<Content> contents = queryFactory
         .selectFrom(content)
@@ -118,18 +152,7 @@ public class ContentRepositoryCustom {
   }
 
   private BooleanExpression eqCategoryId(Long categoryId) {
-    if (validateWhetherAllTypeOrNot(categoryId)) {
-      return null;
-    }
     return content.category.id.eq(categoryId);
-  }
-
-  private boolean validateWhetherAllTypeOrNot(Long categoryId) {
-    if (categoryId == 0) {
-      // 전체 카테고리 id == 0
-      return true;
-    }
-    return false;
   }
 
   private BooleanExpression beforeNDays(long day) {

--- a/src/main/java/com/hyperlink/server/domain/memberContent/application/MemberContentService.java
+++ b/src/main/java/com/hyperlink/server/domain/memberContent/application/MemberContentService.java
@@ -31,6 +31,7 @@ public class MemberContentService {
   }
 
   public boolean isBookmarked(Long memberId, Long contentId) {
+    if(memberId == null) return false;
     return memberContentRepository.findMemberContentByMemberIdAndContentIdAndType(
         memberId, contentId, BOOKMARK.getTypeNumber()).isPresent();
   }

--- a/src/main/java/com/hyperlink/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/hyperlink/server/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.hyperlink.server.global.exception;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.validation.ConstraintViolationException;
 import javax.validation.ValidationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -8,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -39,6 +41,18 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(HttpMessageNotReadableException.class)
   public ResponseEntity<ErrorResponse> handleInvalidRequestBody() {
     ErrorResponse errorResponse = new ErrorResponse("잘못된 형식의 Request Body 입니다!");
+    return ResponseEntity.badRequest().body(errorResponse);
+  }
+
+  @ExceptionHandler(ConstraintViolationException.class)
+  public ResponseEntity<ErrorResponse> handleInvalidRequestParam() {
+    ErrorResponse errorResponse = new ErrorResponse("잘못된 형식의 Query String 혹은 Path Parameter 입니다.");
+    return ResponseEntity.badRequest().body(errorResponse);
+  }
+
+  @ExceptionHandler(MissingServletRequestParameterException.class)
+  public ResponseEntity<ErrorResponse> handleMissingRequestParam() {
+    ErrorResponse errorResponse = new ErrorResponse("Query String 혹은 Path Parameter가 누락되었습니다.");
     return ResponseEntity.badRequest().body(errorResponse);
   }
 

--- a/src/main/java/com/hyperlink/server/global/filter/AuthenticationFilter.java
+++ b/src/main/java/com/hyperlink/server/global/filter/AuthenticationFilter.java
@@ -22,7 +22,7 @@ public class AuthenticationFilter implements Filter {
 
   private static final String[] whitelist = {"/", "/members/logout", "/members/login",
       "/members/signup", "/profile", "/actuator/health", "/members/oauth/code/google",
-      "/members/access-token"};
+      "/members/access-token", "/contents"};
 
   private final AuthTokenExtractor authTokenExtractor;
   private final JwtTokenProvider jwtTokenProvider;

--- a/src/test/java/com/hyperlink/server/content/application/ContentServiceIntegrationTest.java
+++ b/src/test/java/com/hyperlink/server/content/application/ContentServiceIntegrationTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -325,6 +326,66 @@ public class ContentServiceIntegrationTest {
 
         assertThrows(CategoryNotFoundException.class,
             () -> contentService.insertContent(contentEnrollResponse));
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("[Admin] 컨텐츠 활성화 메서드는")
+  class ActivateContent {
+
+    @TestInstance(Lifecycle.PER_CLASS)
+    @TestMethodOrder(OrderAnnotation.class)
+    @Rollback(value = false)
+    @Nested
+    @DisplayName("[성공] 활성화 버튼은 누르면")
+    class Success {
+
+      Content savedContent;
+
+      @BeforeAll
+      void setUp() {
+        savedContent = contentRepository.save(
+            new Content("개발글은 이렇게!!!!!", "contentImgUrl", "link", creator, category));
+      }
+
+      @Order(1)
+      @Test
+      @DisplayName("컨텐츠의 is_viewable을 true로 변경하고")
+      void makeIsViewablePropertyTrue() {
+        contentService.activateContent(savedContent.getId());
+        Content content = contentRepository.findById(savedContent.getId()).get();
+
+        Assertions.assertTrue(content.isViewable());
+      }
+
+      @Order(2)
+      @Test
+      @DisplayName("true를 갖는다.")
+      void checkIsViewablePropertyTrue() {
+        Content content = contentRepository.findById(savedContent.getId()).get();
+        Assertions.assertTrue(content.isViewable());
+      }
+
+
+      @AfterAll
+      void tearDown() {
+        contentRepository.deleteById(savedContent.getId());
+      }
+
+    }
+
+    @Nested
+    @DisplayName("[실패]")
+    class Fail {
+      @Test
+      @DisplayName("유효하지 않은 content id에 대해서는 ContentNotFoundException 을 발생한다.")
+      void throwContentNotFoundExceptionWhenInvalidContentId() {
+        Long invalidContentId = -1L;
+
+        Assertions.assertThrows(ContentNotFoundException.class,
+            () -> contentService.activateContent(invalidContentId));
+
       }
     }
   }

--- a/src/test/java/com/hyperlink/server/content/application/ContentServiceIntegrationTest.java
+++ b/src/test/java/com/hyperlink/server/content/application/ContentServiceIntegrationTest.java
@@ -3,6 +3,7 @@ package com.hyperlink.server.content.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -14,6 +15,8 @@ import com.hyperlink.server.domain.content.application.ContentService;
 import com.hyperlink.server.domain.content.domain.ContentRepository;
 import com.hyperlink.server.domain.content.domain.entity.Content;
 import com.hyperlink.server.domain.content.dto.ContentEnrollResponse;
+import com.hyperlink.server.domain.content.dto.ContentResponse;
+import com.hyperlink.server.domain.content.dto.GetContentsCommonResponse;
 import com.hyperlink.server.domain.content.dto.SearchResponse;
 import com.hyperlink.server.domain.content.exception.ContentNotFoundException;
 import com.hyperlink.server.domain.creator.domain.CreatorRepository;
@@ -29,7 +32,6 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -356,7 +358,7 @@ public class ContentServiceIntegrationTest {
         contentService.activateContent(savedContent.getId());
         Content content = contentRepository.findById(savedContent.getId()).get();
 
-        Assertions.assertTrue(content.isViewable());
+        assertTrue(content.isViewable());
       }
 
       @Order(2)
@@ -364,7 +366,7 @@ public class ContentServiceIntegrationTest {
       @DisplayName("true를 갖는다.")
       void checkIsViewablePropertyTrue() {
         Content content = contentRepository.findById(savedContent.getId()).get();
-        Assertions.assertTrue(content.isViewable());
+        assertTrue(content.isViewable());
       }
 
 
@@ -383,9 +385,126 @@ public class ContentServiceIntegrationTest {
       void throwContentNotFoundExceptionWhenInvalidContentId() {
         Long invalidContentId = -1L;
 
-        Assertions.assertThrows(ContentNotFoundException.class,
+        assertThrows(ContentNotFoundException.class,
             () -> contentService.activateContent(invalidContentId));
 
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("컨텐츠 조회 메서드는")
+  class Retrieve {
+
+    Content content1;
+    Content content2;
+    Content content3;
+    Content content4;
+
+    @BeforeEach
+    void setUp() {
+      Creator creator2 = new Creator("코딩팩토리", "profileUrl", "description", category);
+      creatorRepository.save(creator2);
+
+      content1 = contentRepository.save(
+          new Content("제목1", "contentImgUrl1", "link1", creator, category));
+      content2 = contentRepository.save(
+          new Content("제목2", "contentImgUrl2", "link2", creator, category));
+      content3 = contentRepository.save(
+          new Content("제목3", "contentImgUrl3", "link3", creator, category));
+      content4 = contentRepository.save(
+          new Content("제목4", "contentImgUrl4", "link4", creator2, category));
+
+    }
+
+    @Nested
+    @DisplayName("트렌드를")
+    class TrendContent {
+
+      @Test
+      @DisplayName("최신순으로 조회할 수 있다.")
+      void retrieveRecent() {
+        GetContentsCommonResponse getContentsCommonResponse = contentService.retrieveTrendContents(
+            null, "개발", "recent", PageRequest.of(0, 10));
+
+        List<ContentResponse> contents = getContentsCommonResponse.contents();
+        assertThat(contents).hasSize(4);
+        assertThat(contents.get(0).createdAt()).isLessThanOrEqualTo(
+            contents.get(contents.size() - 1).createdAt());
+      }
+
+      @Test
+      @DisplayName("인기순으로 조회할 수 있다.")
+      void retrievePopular() {
+        Member member = memberRepository.save(new Member("email", "nickname", Career.DEVELOP,
+            CareerYear.LESS_THAN_ONE, "profileImgUrl"));
+        memberRepository.save(member);
+        contentService.addView(member.getId(), content4.getId());
+        contentService.addView(member.getId(), content4.getId());
+        contentService.addView(member.getId(), content4.getId());
+
+        contentService.addView(member.getId(), content3.getId());
+        contentService.addView(member.getId(), content3.getId());
+
+        GetContentsCommonResponse getContentsCommonResponse = contentService.retrieveTrendContents(
+            null, "개발", "popular", PageRequest.of(0, 10));
+
+        List<ContentResponse> contents = getContentsCommonResponse.contents();
+        assertThat(contents).hasSize(4);
+        assertThat(contents.get(0).title()).isEqualTo("제목4");
+        assertThat(contents.get(1).title()).isEqualTo("제목3");
+      }
+
+      @Nested
+      @DisplayName("[실패]")
+      class Fail {
+        @Test
+        @DisplayName("카테고리가 잘못 입력되면 CategoryNotFoundException을 발생한다.")
+        void throwCategoryNotFoundExceptionForInvalidCategory() {
+          String categoryName = "invalidCategory";
+
+          assertThrows(CategoryNotFoundException.class,
+              () -> contentService.retrieveTrendContents(null, categoryName, "recent",
+                  PageRequest.of(0, 10)));
+        }
+
+      }
+    }
+
+    @Nested
+    @DisplayName("크리에이터의 글을")
+    class CreatorContent {
+      @Test
+      @DisplayName("최신순으로 조회할 수 있다.")
+      void retrieveRecent() {
+        GetContentsCommonResponse getContentsCommonResponse = contentService.retrieveCreatorContents(
+            null, creator.getId(), "recent", PageRequest.of(0, 10));
+
+        List<ContentResponse> contents = getContentsCommonResponse.contents();
+        assertThat(contents).hasSize(3);
+        assertThat(contents.get(0).createdAt()).isLessThanOrEqualTo(
+            contents.get(contents.size() - 1).createdAt());
+      }
+
+      @Test
+      @DisplayName("인기순으로 조회할 수 있다.")
+      void retrievePopular() {
+        Member member = memberRepository.save(new Member("email", "nickname", Career.DEVELOP,
+            CareerYear.LESS_THAN_ONE, "profileImgUrl"));
+        memberRepository.save(member);
+        contentService.addView(member.getId(), content4.getId());
+        contentService.addView(member.getId(), content4.getId());
+        contentService.addView(member.getId(), content4.getId());
+
+        contentService.addView(member.getId(), content3.getId());
+        contentService.addView(member.getId(), content3.getId());
+
+        GetContentsCommonResponse getContentsCommonResponse = contentService.retrieveCreatorContents(
+            null, creator.getId(), "popular", PageRequest.of(0, 10));
+
+        List<ContentResponse> contents = getContentsCommonResponse.contents();
+        assertThat(contents).hasSize(3);
+        assertThat(contents.get(0).title()).isEqualTo("제목3");
       }
     }
   }

--- a/src/test/java/com/hyperlink/server/content/controller/ContentControllerTest.java
+++ b/src/test/java/com/hyperlink/server/content/controller/ContentControllerTest.java
@@ -25,16 +25,22 @@ import com.hyperlink.server.domain.content.dto.ContentResponse;
 import com.hyperlink.server.domain.content.dto.GetContentsCommonResponse;
 import com.hyperlink.server.domain.content.dto.RecommendationCompanyResponse;
 import com.hyperlink.server.domain.content.dto.SearchResponse;
+import com.hyperlink.server.domain.content.exception.CategoryAndCreatorIdConstraintViolationException;
 import com.hyperlink.server.domain.content.exception.ContentNotFoundException;
 import java.util.List;
+import java.util.stream.Stream;
 import javax.validation.ValidationException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -47,6 +53,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 
 @WebMvcTest(ContentController.class)
 @MockBean(JpaMetamodelMappingContext.class)
@@ -265,5 +272,214 @@ public class ContentControllerTest extends AuthSetupForMock {
     }
 
 
+  }
+
+  @Nested
+  @DisplayName("트렌드, 크링에이터별 컨텐츠 조회 API는")
+  class RetrieveContent {
+
+    String page = "0";
+    String size = "10";
+
+    @BeforeEach
+    void setUp() {
+      authSetup();
+    }
+
+    @TestInstance(Lifecycle.PER_CLASS)
+    @Nested
+    @DisplayName("트렌드 게시글")
+    class Trend {
+
+      Stream<Arguments> createInput() {
+        return Stream.of(
+            Arguments.of("develop", null, "popular"),
+            Arguments.of("develop", null, "recent")
+        );
+      }
+
+      @ParameterizedTest
+      @MethodSource("createInput")
+      @DisplayName("[category]와 [sort] 를 입력받으면 인기순 트렌드를 조회한다.")
+      void retrievePopularTrend(String category, Long creatorId, String sort) throws Exception {
+        List<RecommendationCompanyResponse> recommendationCompanyResponses = List.of(
+            new RecommendationCompanyResponse("네이버", "https://naverlogo.com"));
+        List<RecommendationCompanyResponse> recommendationCompanyResponses2 = List.of(
+            new RecommendationCompanyResponse("네이버", "https://naverlogo.com"),
+            new RecommendationCompanyResponse("카카오", "https://kakaologo.com"));
+        ContentResponse contentResponse = new ContentResponse(1L, "개발자의 삶", "개발왕김딴딴", 2L,
+            "https://img1.com", "https://okky.kr/articles/503803", 4,
+            100, false, false, "2023-02-17T12:30.334", recommendationCompanyResponses);
+        ContentResponse contentResponse2 = new ContentResponse(2L, "당신은 개발자가 맞는가?", "개발왕김딴딴", 2L,
+            "https://img2.com", "https://okky.kr/articles/503343", 1,
+            35, false, false, "2023-02-17T12:30.334", recommendationCompanyResponses2);
+        List<ContentResponse> contentResponses = List.of(contentResponse, contentResponse2);
+        GetContentsCommonResponse getContentsCommonResponse = new GetContentsCommonResponse(
+            contentResponses, true);
+
+        Long memberId = 1L;
+        Pageable pageable = PageRequest.of(Integer.parseInt(page), Integer.parseInt(size));
+
+        doReturn(getContentsCommonResponse).when(contentService)
+            .retrieveTrendContents(memberId, category, sort, pageable);
+
+        mockMvc.perform(
+                get("/contents")
+                    .param("sort", sort)
+                    .param("page", page)
+                    .param("size", size)
+                    .param("category", category)
+                    .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                    .characterEncoding("UTF-8")
+            ).andExpect(status().isOk())
+            .andDo(print())
+            .andDo(
+                document(
+                    "ContentControllerTest/retrieve",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    requestHeaders(
+                        headerWithName(HttpHeaders.AUTHORIZATION).description("AccessToken")
+                    ),
+                    responseFields(
+                        fieldWithPath("contents.[].contentId").type(JsonFieldType.NUMBER)
+                            .description("컨텐츠 id"),
+                        fieldWithPath("contents.[].title").type(JsonFieldType.STRING)
+                            .description("컨텐츠 제목"),
+                        fieldWithPath("contents.[].creatorName").type(JsonFieldType.STRING)
+                            .description("크리에이터 이름"),
+                        fieldWithPath("contents.[].creatorId").type(JsonFieldType.NUMBER)
+                            .description("크리에이터 id"),
+                        fieldWithPath("contents.[].contentImgUrl").type(JsonFieldType.STRING)
+                            .description("컨텐츠 이미지 URL"),
+                        fieldWithPath("contents.[].link").type(JsonFieldType.STRING)
+                            .description("컨텐츠 연결 외부 링크"),
+                        fieldWithPath("contents.[].likeCount").type(JsonFieldType.NUMBER)
+                            .description("좋아요 개수"),
+                        fieldWithPath("contents.[].viewCount").type(JsonFieldType.NUMBER)
+                            .description("조회수 개수"),
+                        fieldWithPath("contents.[].isBookmarked").type(JsonFieldType.BOOLEAN)
+                            .description("북마크 여부"),
+                        fieldWithPath("contents.[].isLiked").type(JsonFieldType.BOOLEAN)
+                            .description("좋아요 여부"),
+                        fieldWithPath("contents.[].createdAt").type(JsonFieldType.STRING)
+                            .description("컨텐츠 생성 날짜"),
+                        fieldWithPath("contents.[].recommendations").type(
+                            JsonFieldType.ARRAY).description("추천 배열"),
+                        fieldWithPath("contents.[].recommendations.[].bannerName").type(
+                            JsonFieldType.STRING).description("배너명"),
+                        fieldWithPath(
+                            "contents.[].recommendations.[].bannerLogoImgUrl").type(
+                            JsonFieldType.STRING).description("배너 로고 URL"),
+                        fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN)
+                            .description("다음 페이지 존재여부")
+                    )
+                )
+            );
+      }
+
+    }
+
+    @TestInstance(Lifecycle.PER_CLASS)
+    @Nested
+    @DisplayName("크리에이터 별 게시글")
+    class CreatorContent {
+
+      Stream<Arguments> createInput() {
+        return Stream.of(
+            Arguments.of(null, "2", "popular"),
+            Arguments.of(null, "2", "recent")
+        );
+      }
+
+      @ParameterizedTest
+      @MethodSource("createInput")
+      @DisplayName("[creatorId]와 [sort] 를 입력받으면 인기순 트렌드를 조회한다.")
+      void retrievePopularTrend(String category, String creatorId, String sort) throws Exception {
+        List<RecommendationCompanyResponse> recommendationCompanyResponses = List.of(
+            new RecommendationCompanyResponse("네이버", "https://naverlogo.com"));
+        List<RecommendationCompanyResponse> recommendationCompanyResponses2 = List.of(
+            new RecommendationCompanyResponse("네이버", "https://naverlogo.com"),
+            new RecommendationCompanyResponse("카카오", "https://kakaologo.com"));
+        ContentResponse contentResponse = new ContentResponse(1L, "개발자의 삶", "개발왕김딴딴", 2L,
+            "https://img1.com", "https://okky.kr/articles/503803", 4,
+            100, false, false, "2023-02-17T12:30.334", recommendationCompanyResponses);
+        ContentResponse contentResponse2 = new ContentResponse(2L, "당신은 개발자가 맞는가?", "개발왕김딴딴", 2L,
+            "https://img2.com", "https://okky.kr/articles/503343", 1,
+            35, false, false, "2023-02-17T12:30.334", recommendationCompanyResponses2);
+        List<ContentResponse> contentResponses = List.of(contentResponse, contentResponse2);
+        GetContentsCommonResponse getContentsCommonResponse = new GetContentsCommonResponse(
+            contentResponses, true);
+
+        Long memberId = 1L;
+        Pageable pageable = PageRequest.of(Integer.parseInt(page), Integer.parseInt(size));
+
+        doReturn(getContentsCommonResponse).when(contentService)
+            .retrieveTrendContents(memberId, category, sort, pageable);
+        doReturn(getContentsCommonResponse).when(contentService)
+            .retrieveCreatorContents(memberId, Long.parseLong(creatorId), sort, pageable);
+
+        mockMvc.perform(
+            get("/contents")
+                .param("sort", sort)
+                .param("page", page)
+                .param("size", size)
+                .param("creatorId", creatorId)
+                .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                .characterEncoding("UTF-8")
+        ).andExpect(status().isOk());
+      }
+    }
+
+    @Nested
+    @DisplayName("[실패]")
+    class Fail {
+
+      @Test
+      @DisplayName("category와 creatorId를 동시에 입력하면 CategoryAndCreatorIdConstraintViolationException이 발생한다.")
+      void bothCategoryAndCreatorId() throws Exception {
+        String category = "개발";
+        String creatorId = "2";
+        String page = "0";
+        String size = "10";
+        String sort = "recent";
+
+        mockMvc.perform(
+                get("/contents")
+                    .param("sort", sort)
+                    .param("page", page)
+                    .param("size", size)
+                    .param("creatorId", creatorId)
+                    .param("category", category)
+                    .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                    .characterEncoding("UTF-8")
+            ).andExpect(status().isBadRequest())
+            .andExpect(response -> Assertions.assertTrue(
+                response.getResolvedException() instanceof CategoryAndCreatorIdConstraintViolationException));
+
+      }
+
+      @Test
+      @DisplayName("파라미터 값이 유효하지 않거나 필수 파라미터가 입력되지 않으면 MissingServletRequestParameterException이 발생한다.")
+      void missingArgumentOrInvalidArgument() throws Exception {
+        String creatorId = "-1";
+        String page = null;
+        String size = null;
+        String sort = null;
+
+        mockMvc.perform(
+                get("/contents")
+                    .param("sort", sort)
+                    .param("page", page)
+                    .param("size", size)
+                    .param("creatorId", creatorId)
+                    .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                    .characterEncoding("UTF-8")
+            ).andExpect(status().isBadRequest())
+            .andExpect(response -> Assertions.assertTrue(
+                response.getResolvedException() instanceof MissingServletRequestParameterException));
+
+      }
+    }
   }
 }

--- a/src/test/java/com/hyperlink/server/content/controller/ContentControllerTest.java
+++ b/src/test/java/com/hyperlink/server/content/controller/ContentControllerTest.java
@@ -188,12 +188,12 @@ public class ContentControllerTest extends AuthSetupForMock {
                             .description("좋아요 여부"),
                         fieldWithPath("contents.[].createdAt").type(JsonFieldType.STRING)
                             .description("컨텐츠 생성 날짜"),
-                        fieldWithPath("contents.[].recommendationCompanies").type(
+                        fieldWithPath("contents.[].recommendations").type(
                             JsonFieldType.ARRAY).description("회사 추천 배열"),
-                        fieldWithPath("contents.[].recommendationCompanies.[].companyName").type(
+                        fieldWithPath("contents.[].recommendations.[].bannerName").type(
                             JsonFieldType.STRING).description("회사명"),
                         fieldWithPath(
-                            "contents.[].recommendationCompanies.[].companyLogoImgUrl").type(
+                            "contents.[].recommendations.[].bannerLogoImgUrl").type(
                             JsonFieldType.STRING).description("회사 로고 URL"),
                         fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN)
                             .description("다음 페이지 존재여부"),

--- a/src/test/java/com/hyperlink/server/content/controller/ContentControllerTest.java
+++ b/src/test/java/com/hyperlink/server/content/controller/ContentControllerTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EmptySource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -300,7 +301,7 @@ public class ContentControllerTest extends AuthSetupForMock {
 
       @ParameterizedTest
       @MethodSource("createInput")
-      @DisplayName("[category]와 [sort] 를 입력받으면 인기순 트렌드를 조회한다.")
+      @DisplayName("[category]와 [sort] 를 입력받으면 인기순, 최신순 트렌드를 조회한다.")
       void retrievePopularTrend(String category, Long creatorId, String sort) throws Exception {
         List<RecommendationCompanyResponse> recommendationCompanyResponses = List.of(
             new RecommendationCompanyResponse("네이버", "https://naverlogo.com"));
@@ -378,6 +379,84 @@ public class ContentControllerTest extends AuthSetupForMock {
             );
       }
 
+      @ParameterizedTest
+      @ValueSource(strings = {"popular", "recent"})
+      @DisplayName("전체 카테고리에 대해서 인기순, 최신순 트렌드를 조회한다.")
+      void retrieveTrendForAllCategories(String sort) throws Exception {
+        List<RecommendationCompanyResponse> recommendationCompanyResponses = List.of(
+            new RecommendationCompanyResponse("네이버", "https://naverlogo.com"));
+        List<RecommendationCompanyResponse> recommendationCompanyResponses2 = List.of(
+            new RecommendationCompanyResponse("네이버", "https://naverlogo.com"),
+            new RecommendationCompanyResponse("카카오", "https://kakaologo.com"));
+        ContentResponse contentResponse = new ContentResponse(1L, "개발자의 삶", "개발왕김딴딴", 2L,
+            "https://img1.com", "https://okky.kr/articles/503803", 4,
+            100, false, false, "2023-02-17T12:30.334", recommendationCompanyResponses);
+        ContentResponse contentResponse2 = new ContentResponse(2L, "당신은 개발자가 맞는가?", "개발왕김딴딴", 2L,
+            "https://img2.com", "https://okky.kr/articles/503343", 1,
+            35, false, false, "2023-02-17T12:30.334", recommendationCompanyResponses2);
+        List<ContentResponse> contentResponses = List.of(contentResponse, contentResponse2);
+        GetContentsCommonResponse getContentsCommonResponse = new GetContentsCommonResponse(
+            contentResponses, true);
+
+        Long memberId = 1L;
+        Pageable pageable = PageRequest.of(Integer.parseInt(page), Integer.parseInt(size));
+
+        doReturn(getContentsCommonResponse).when(contentService)
+            .retrieveTrendAllCategoriesContents(memberId, sort, pageable);
+
+        mockMvc.perform(
+                get("/contents/all")
+                    .param("sort", sort)
+                    .param("page", page)
+                    .param("size", size)
+                    .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                    .characterEncoding("UTF-8")
+            ).andExpect(status().isOk())
+            .andDo(print())
+            .andDo(
+                document(
+                    "ContentControllerTest/retrieve",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    requestHeaders(
+                        headerWithName(HttpHeaders.AUTHORIZATION).description("AccessToken")
+                    ),
+                    responseFields(
+                        fieldWithPath("contents.[].contentId").type(JsonFieldType.NUMBER)
+                            .description("컨텐츠 id"),
+                        fieldWithPath("contents.[].title").type(JsonFieldType.STRING)
+                            .description("컨텐츠 제목"),
+                        fieldWithPath("contents.[].creatorName").type(JsonFieldType.STRING)
+                            .description("크리에이터 이름"),
+                        fieldWithPath("contents.[].creatorId").type(JsonFieldType.NUMBER)
+                            .description("크리에이터 id"),
+                        fieldWithPath("contents.[].contentImgUrl").type(JsonFieldType.STRING)
+                            .description("컨텐츠 이미지 URL"),
+                        fieldWithPath("contents.[].link").type(JsonFieldType.STRING)
+                            .description("컨텐츠 연결 외부 링크"),
+                        fieldWithPath("contents.[].likeCount").type(JsonFieldType.NUMBER)
+                            .description("좋아요 개수"),
+                        fieldWithPath("contents.[].viewCount").type(JsonFieldType.NUMBER)
+                            .description("조회수 개수"),
+                        fieldWithPath("contents.[].isBookmarked").type(JsonFieldType.BOOLEAN)
+                            .description("북마크 여부"),
+                        fieldWithPath("contents.[].isLiked").type(JsonFieldType.BOOLEAN)
+                            .description("좋아요 여부"),
+                        fieldWithPath("contents.[].createdAt").type(JsonFieldType.STRING)
+                            .description("컨텐츠 생성 날짜"),
+                        fieldWithPath("contents.[].recommendations").type(
+                            JsonFieldType.ARRAY).description("추천 배열"),
+                        fieldWithPath("contents.[].recommendations.[].bannerName").type(
+                            JsonFieldType.STRING).description("배너명"),
+                        fieldWithPath(
+                            "contents.[].recommendations.[].bannerLogoImgUrl").type(
+                            JsonFieldType.STRING).description("배너 로고 URL"),
+                        fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN)
+                            .description("다음 페이지 존재여부")
+                    )
+                )
+            );
+      }
     }
 
     @TestInstance(Lifecycle.PER_CLASS)

--- a/src/test/java/com/hyperlink/server/memberHistory/controller/MemberHistoryControllerTest.java
+++ b/src/test/java/com/hyperlink/server/memberHistory/controller/MemberHistoryControllerTest.java
@@ -134,12 +134,12 @@ public class MemberHistoryControllerTest extends AuthSetupForMock {
                             .description("좋아요 여부"),
                         fieldWithPath("contents.[].createdAt").type(JsonFieldType.STRING)
                             .description("컨텐츠 생성 날짜"),
-                        fieldWithPath("contents.[].recommendationCompanies").type(
+                        fieldWithPath("contents.[].recommendations").type(
                             JsonFieldType.ARRAY).description("회사 추천 배열"),
-                        fieldWithPath("contents.[].recommendationCompanies.[].companyName").type(
+                        fieldWithPath("contents.[].recommendations.[].bannerName").type(
                             JsonFieldType.STRING).description("회사명"),
                         fieldWithPath(
-                            "contents.[].recommendationCompanies.[].companyLogoImgUrl").type(
+                            "contents.[].recommendations.[].bannerLogoImgUrl").type(
                             JsonFieldType.STRING).description("회사 로고 URL"),
                         fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN)
                             .description("다음 페이지 존재여부")


### PR DESCRIPTION
### 변경 내용 요약
- 메인 페이지에 보일 컨텐츠 전체보기 기능을 구현했습니다.

### 작업한 내용
- 카테고리 별로 최신, 인기 트렌드 보기
- 크리에이터 별로 최신, 인기 트렌드 보기
- 인기 트렌드의 경우 과거의 데이터를 가져오면 좋지 않을 것으로 판단하여 최근 5일 내의 데이터로 한정하여 조회하였습니다.
- 또한 정렬 기준은 조회수의 경우 1점, 좋아요수의 경우 3점으로 환산하여 합산 결과를 기반으로 정렬하였습니다.


### 기타사항
- 작업한 내용은 기획상 로그인하지 않은 유저도 조회할 수 있으며 이 때 북마크 여부와 좋아요 여부는 모두 false 처리해야하기 때문에 예지님이 작업하셨던 isBookmarked 메서드를 조금 수정했습니다.

close #143