### PR TITLE
[#160] 구독 피드 목록 조회 API 구현

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -17,7 +17,11 @@ operation::ContentControllerTest/addInquiryOfContent[snippets='http-request,http
 
 operation::ContentControllerTest/search[snippets='http-request,http-response,response-fields']
 
-=== 조회
+=== 전체 카테고리 조회
+
+operation::ContentControllerTest/retrieveAllCategory[snippets="http-request,http-response"]
+
+=== 카테고리별 조회
 
 operation::ContentControllerTest/retrieve[snippets="http-request,http-response"]
 
@@ -64,6 +68,12 @@ operation::CreatorControllerTest/notRecommend[snippets='http-request,http-respon
 == Subscription
 === 크리에이터 구독/구독 취소
 operation::SubscriptionControllerTest/subscribeOrUnsubscribeCreator[snippets='http-request,http-response']
+
+=== 구독 피드 카테고리별 조회
+operation::SubscriptionControllerTest/retrieveByCategory[snippets='http-request,http-response']
+
+=== 구독 피드 전체 카테고리 조회
+operation::SubscriptionControllerTest/retrieveAllCategory[snippets='http-request,http-response']
 
 == Admin
 

--- a/src/main/java/com/hyperlink/server/domain/content/infrastructure/ContentRepositoryCustom.java
+++ b/src/main/java/com/hyperlink/server/domain/content/infrastructure/ContentRepositoryCustom.java
@@ -27,7 +27,8 @@ public class ContentRepositoryCustom {
 
   private final JPAQueryFactory queryFactory;
 
-  public Slice<Content> searchByTitleContainingOrderByLatest(List<String> keywords, Pageable pageable) {
+  public Slice<Content> searchByTitleContainingOrderByLatest(List<String> keywords,
+      Pageable pageable) {
     BooleanBuilder builder = new BooleanBuilder();
     for (String keyword : keywords) {
       builder.or(content.title.contains(keyword));
@@ -72,9 +73,10 @@ public class ContentRepositoryCustom {
     return getSlice(pageable, contents);
   }
 
-  public Slice<Content> retrievePopularTrendContentsForCategories(List<Long> categoryIds, Pageable pageable) {
+  public Slice<Content> retrievePopularTrendContentsForCategories(List<Long> categoryIds,
+      Pageable pageable) {
     BooleanBuilder categoryConditionBuilder = new BooleanBuilder();
-    for(Long categoryId : categoryIds) {
+    for (Long categoryId : categoryIds) {
       categoryConditionBuilder.or(content.category.id.eq(categoryId));
     }
 
@@ -89,9 +91,10 @@ public class ContentRepositoryCustom {
     return getSlice(pageable, contents);
   }
 
-  public Slice<Content> retrieveRecentTrendContentsForCategories(List<Long> categoryIds, Pageable pageable) {
+  public Slice<Content> retrieveRecentTrendContentsForCategories(List<Long> categoryIds,
+      Pageable pageable) {
     BooleanBuilder categoryConditionBuilder = new BooleanBuilder();
-    for(Long categoryId : categoryIds) {
+    for (Long categoryId : categoryIds) {
       categoryConditionBuilder.or(content.category.id.eq(categoryId));
     }
 
@@ -122,6 +125,42 @@ public class ContentRepositoryCustom {
     List<Content> contents = queryFactory
         .selectFrom(content)
         .where(eqCreatorId(creatorId))
+        .orderBy(recentOrderType())
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize() + 1)
+        .fetch();
+
+    return getSlice(pageable, contents);
+  }
+
+  public Slice<Content> retrieveRecentContentsSubscribedCreatorsByCategoryId(
+      List<Long> subscribedCreatorIds, Long categoryId, Pageable pageable) {
+    BooleanBuilder subscribedCreatorConditionBuilder = new BooleanBuilder();
+    for (Long creatorId : subscribedCreatorIds) {
+      subscribedCreatorConditionBuilder.or(content.creator.id.eq(creatorId));
+    }
+
+    List<Content> contents = queryFactory
+        .selectFrom(content)
+        .where(subscribedCreatorConditionBuilder, eqCategoryId(categoryId))
+        .orderBy(recentOrderType())
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize() + 1)
+        .fetch();
+
+    return getSlice(pageable, contents);
+  }
+
+  public Slice<Content> retrieveRecentContentsForAllSubscribedCreators(
+      List<Long> subscribedCreatorIds, Pageable pageable) {
+    BooleanBuilder subscribedCreatorConditionBuilder = new BooleanBuilder();
+    for (Long creatorId : subscribedCreatorIds) {
+      subscribedCreatorConditionBuilder.or(content.creator.id.eq(creatorId));
+    }
+
+    List<Content> contents = queryFactory
+        .selectFrom(content)
+        .where(subscribedCreatorConditionBuilder)
         .orderBy(recentOrderType())
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize() + 1)

--- a/src/main/java/com/hyperlink/server/domain/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/hyperlink/server/domain/subscription/controller/SubscriptionController.java
@@ -1,14 +1,19 @@
 package com.hyperlink.server.domain.subscription.controller;
 
 import com.hyperlink.server.domain.auth.token.exception.TokenNotExistsException;
+import com.hyperlink.server.domain.content.dto.GetContentsCommonResponse;
 import com.hyperlink.server.domain.subscription.dto.SubscribeResponse;
 import com.hyperlink.server.domain.subscription.application.SubscriptionService;
 import com.hyperlink.server.global.config.LoginMemberId;
 import java.util.Optional;
+import javax.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,5 +31,23 @@ public class SubscriptionController {
     return subscriptionService.subscribeOrUnsubscribeCreator(loginMemberId, creatorId);
   }
 
+  @GetMapping("/subscriptions/contents")
+  @ResponseStatus(HttpStatus.OK)
+  public GetContentsCommonResponse retrieveSubscribedContents(@LoginMemberId Optional<Long> optionalMemberId,
+      @RequestParam("category") @NotNull String category,
+      @RequestParam("page") @NotNull int page,
+      @RequestParam("size") @NotNull int size) {
+    Long loginMemberId = optionalMemberId.orElseThrow(TokenNotExistsException::new);
+    return subscriptionService.retrieveSubscribedCreatorsContentsByCategoryId(loginMemberId, category, PageRequest.of(page, size));
+  }
+
+  @GetMapping("/subscriptions/contents/all")
+  @ResponseStatus(HttpStatus.OK)
+  public GetContentsCommonResponse retrieveSubscribedContents(@LoginMemberId Optional<Long> optionalMemberId,
+      @RequestParam("page") @NotNull int page,
+      @RequestParam("size") @NotNull int size) {
+    Long loginMemberId = optionalMemberId.orElseThrow(TokenNotExistsException::new);
+    return subscriptionService.retrieveSubscribedCreatorsContentsForAllCategories(loginMemberId, PageRequest.of(page, size));
+  }
 
 }

--- a/src/main/java/com/hyperlink/server/domain/subscription/domain/SubscriptionRepository.java
+++ b/src/main/java/com/hyperlink/server/domain/subscription/domain/SubscriptionRepository.java
@@ -1,11 +1,16 @@
 package com.hyperlink.server.domain.subscription.domain;
 
 import com.hyperlink.server.domain.subscription.domain.entity.Subscription;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
 
   boolean existsByMemberIdAndCreatorId(Long memberId, Long creatorId);
   void deleteByMemberIdAndCreatorId(Long memberId, Long creatorId);
+
+  @Query("select sub.creator.id from Subscription sub where sub.member.id = :memberId")
+  List<Long> findCreatorIdByMemberId(Long memberId);
 }

--- a/src/test/java/com/hyperlink/server/content/application/ContentServiceIntegrationTest.java
+++ b/src/test/java/com/hyperlink/server/content/application/ContentServiceIntegrationTest.java
@@ -453,8 +453,8 @@ public class ContentServiceIntegrationTest {
         @Test
         @DisplayName("인기순으로 조회할 수 있다.")
         void retrievePopular() {
-          contentService.addView(member.getId(), content3.getId());
-          contentService.addView(member.getId(), content3.getId());
+          contentService.addView(Optional.of(member.getId()), content3.getId());
+          contentService.addView(Optional.of(member.getId()), content3.getId());
 
           GetContentsCommonResponse getContentsCommonResponse = contentService.retrieveTrendContents(
               null, "개발", "popular", PageRequest.of(0, 10));
@@ -503,12 +503,12 @@ public class ContentServiceIntegrationTest {
           @Test
           @DisplayName("카테고리 전체에 대해 인기순으로 조회할 수 있다.")
           public void retrieveForAttentionCategoryByPopular() throws Exception {
-            contentService.addView(member.getId(), content4.getId());
-            contentService.addView(member.getId(), content4.getId());
-            contentService.addView(member.getId(), content4.getId());
+            contentService.addView(Optional.of(member.getId()), content4.getId());
+            contentService.addView(Optional.of(member.getId()), content4.getId());
+            contentService.addView(Optional.of(member.getId()), content4.getId());
 
-            contentService.addView(member.getId(), content3.getId());
-            contentService.addView(member.getId(), content3.getId());
+            contentService.addView(Optional.of(member.getId()), content3.getId());
+            contentService.addView(Optional.of(member.getId()), content3.getId());
 
             GetContentsCommonResponse getContentsCommonResponse = contentService.retrieveTrendAllCategoriesContents(
                 null, "popular", PageRequest.of(0, 10));
@@ -538,12 +538,12 @@ public class ContentServiceIntegrationTest {
           @Test
           @DisplayName("유저의 관심 카테고리 전체에 대해 인기순으로 조회할 수 있다.")
           public void retrieveForAttentionCategoryByPopular() throws Exception {
-            contentService.addView(member.getId(), content4.getId());
-            contentService.addView(member.getId(), content4.getId());
-            contentService.addView(member.getId(), content4.getId());
+            contentService.addView(Optional.of(member.getId()), content4.getId());
+            contentService.addView(Optional.of(member.getId()), content4.getId());
+            contentService.addView(Optional.of(member.getId()), content4.getId());
 
-            contentService.addView(member.getId(), content3.getId());
-            contentService.addView(member.getId(), content3.getId());
+            contentService.addView(Optional.of(member.getId()), content3.getId());
+            contentService.addView(Optional.of(member.getId()), content3.getId());
 
             GetContentsCommonResponse getContentsCommonResponse = contentService.retrieveTrendAllCategoriesContents(
                 member.getId(), "popular", PageRequest.of(0, 10));
@@ -580,12 +580,12 @@ public class ContentServiceIntegrationTest {
         Member member = memberRepository.save(new Member("email", "nickname", Career.DEVELOP,
             CareerYear.LESS_THAN_ONE, "profileImgUrl"));
         memberRepository.save(member);
-        contentService.addView(member.getId(), content4.getId());
-        contentService.addView(member.getId(), content4.getId());
-        contentService.addView(member.getId(), content4.getId());
+        contentService.addView(Optional.of(member.getId()), content4.getId());
+        contentService.addView(Optional.of(member.getId()), content4.getId());
+        contentService.addView(Optional.of(member.getId()), content4.getId());
 
-        contentService.addView(member.getId(), content3.getId());
-        contentService.addView(member.getId(), content3.getId());
+        contentService.addView(Optional.of(member.getId()), content3.getId());
+        contentService.addView(Optional.of(member.getId()), content3.getId());
 
         GetContentsCommonResponse getContentsCommonResponse = contentService.retrieveCreatorContents(
             null, creator.getId(), "popular", PageRequest.of(0, 10));

--- a/src/test/java/com/hyperlink/server/content/controller/ContentControllerTest.java
+++ b/src/test/java/com/hyperlink/server/content/controller/ContentControllerTest.java
@@ -416,7 +416,7 @@ public class ContentControllerTest extends AuthSetupForMock {
             .andDo(print())
             .andDo(
                 document(
-                    "ContentControllerTest/retrieve",
+                    "ContentControllerTest/retrieveAllCategory",
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
                     requestHeaders(

--- a/src/test/java/com/hyperlink/server/content/controller/ContentControllerTest.java
+++ b/src/test/java/com/hyperlink/server/content/controller/ContentControllerTest.java
@@ -68,8 +68,6 @@ public class ContentControllerTest extends AuthSetupForMock {
   MockMvc mockMvc;
   @Autowired
   ObjectMapper objectMapper;
-  @MockBean
-  JwtTokenProvider jwtTokenProvider;
 
   @Nested
   @DisplayName("조회수 추가 API는")

--- a/src/test/java/com/hyperlink/server/subscription/application/SubscriptionServiceIntegrationTest.java
+++ b/src/test/java/com/hyperlink/server/subscription/application/SubscriptionServiceIntegrationTest.java
@@ -1,10 +1,16 @@
 package com.hyperlink.server.subscription.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hyperlink.server.domain.category.domain.CategoryRepository;
 import com.hyperlink.server.domain.category.domain.entity.Category;
+import com.hyperlink.server.domain.category.exception.CategoryNotFoundException;
+import com.hyperlink.server.domain.content.domain.ContentRepository;
+import com.hyperlink.server.domain.content.domain.entity.Content;
+import com.hyperlink.server.domain.content.dto.GetContentsCommonResponse;
 import com.hyperlink.server.domain.creator.domain.CreatorRepository;
 import com.hyperlink.server.domain.creator.domain.entity.Creator;
 import com.hyperlink.server.domain.creator.exception.CreatorNotFoundException;
@@ -15,6 +21,7 @@ import com.hyperlink.server.domain.member.domain.entity.Member;
 import com.hyperlink.server.domain.member.exception.MemberNotFoundException;
 import com.hyperlink.server.domain.subscription.application.SubscriptionService;
 import com.hyperlink.server.domain.subscription.dto.SubscribeResponse;
+import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,6 +29,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
@@ -37,6 +45,8 @@ public class SubscriptionServiceIntegrationTest {
   CreatorRepository creatorRepository;
   @Autowired
   MemberRepository memberRepository;
+  @Autowired
+  ContentRepository contentRepository;
 
 
   @Nested
@@ -94,6 +104,7 @@ public class SubscriptionServiceIntegrationTest {
     @Nested
     @DisplayName("[실패]")
     class Fail {
+
       Member member;
       Creator creator;
 
@@ -130,5 +141,101 @@ public class SubscriptionServiceIntegrationTest {
 
   }
 
+  @Nested
+  @DisplayName("구독피드 조회 테스트는")
+  class SubscriptionContentRetrievalTest {
 
+    Member member;
+    Category developCategory;
+    Category beautyCategory;
+    Creator creator1;
+    Creator creator2;
+    Content developContent1;
+    Content developContent2;
+    Content developContent3;
+    Content beautyContent1;
+    Content beautyContent2;
+    Content beautyContent3;
+
+    @BeforeEach
+    void setUp() {
+      member = new Member("email", "nickname", Career.DEVELOP, CareerYear.FOUR,
+          "profileImgUrl");
+      developCategory = new Category("개발");
+      beautyCategory = new Category("뷰티");
+      creator1 = new Creator("creatorName1", "profileImgUrl", "description",
+          developCategory);
+      creator2 = new Creator("creatorName2", "profileImgUrl", "description",
+          beautyCategory);
+
+      memberRepository.save(member);
+      categoryRepository.save(developCategory);
+      categoryRepository.save(beautyCategory);
+      creatorRepository.save(creator1);
+      creatorRepository.save(creator2);
+
+      developContent1 = new Content("developtitle1", "img", "link", creator1, developCategory);
+      developContent2 = new Content("developtitle2", "img", "link", creator1, developCategory);
+      developContent3 = new Content("developtitle3", "img", "link", creator1, developCategory);
+      beautyContent1 = new Content("beautytitle1", "img", "link", creator2, beautyCategory);
+      beautyContent2 = new Content("beautytitle2", "img", "link", creator2, beautyCategory);
+      beautyContent3 = new Content("beautytitle3", "img", "link", creator2, beautyCategory);
+      contentRepository.saveAll(
+          List.of(developContent1, developContent2, developContent3, beautyContent1,
+              beautyContent2, beautyContent3));
+
+      subscriptionService.subscribeOrUnsubscribeCreator(member.getId(), creator1.getId());
+      subscriptionService.subscribeOrUnsubscribeCreator(member.getId(), creator2.getId());
+    }
+
+    @Nested
+    @DisplayName("성공")
+    class Success {
+
+      @Test
+      @DisplayName("카테고리 별로 조회할 수 있다.")
+      void retrieveByCategory() {
+        String categoryName = "개발";
+        int page = 0;
+        int size = 10;
+
+        GetContentsCommonResponse getContentsCommonResponse = subscriptionService.retrieveSubscribedCreatorsContentsByCategoryId(
+            member.getId(), categoryName, PageRequest.of(page, size));
+
+        assertThat(getContentsCommonResponse.contents()).hasSize(3);
+        assertThat(getContentsCommonResponse.contents().get(0).title()).startsWith("develop");
+        assertThat(getContentsCommonResponse.contents().get(1).title()).startsWith("develop");
+        assertThat(getContentsCommonResponse.contents().get(2).title()).startsWith("develop");
+      }
+
+      @Test
+      @DisplayName("전체 카테고리에 대해 조회할 수 있다.")
+      void retrieveForAllCategory() {
+        int page = 0;
+        int size = 10;
+
+        GetContentsCommonResponse getContentsCommonResponse = subscriptionService.retrieveSubscribedCreatorsContentsForAllCategories(
+            member.getId(), PageRequest.of(page, size));
+
+        assertThat(getContentsCommonResponse.contents()).hasSize(6);
+      }
+    }
+
+    @Nested
+    @DisplayName("실패")
+    class Fail {
+
+      @Test
+      @DisplayName("카테고리 별로 조회 시 잘못된 카테고리가 들어오면 CategoryNotFoundException 이 발생한다.")
+      void getInvalidCategoryThrowCategoryNotFoundException() {
+        String categoryName = "invalidCategoryName";
+        int page = 0;
+        int size = 10;
+
+        assertThrows(CategoryNotFoundException.class,
+            () -> subscriptionService.retrieveSubscribedCreatorsContentsByCategoryId(member.getId(),
+                categoryName, PageRequest.of(page, size)));
+      }
+    }
+  }
 }

--- a/src/test/java/com/hyperlink/server/subscription/controller/SubscriptionControllerTest.java
+++ b/src/test/java/com/hyperlink/server/subscription/controller/SubscriptionControllerTest.java
@@ -1,6 +1,7 @@
 package com.hyperlink.server.subscription.controller;
 
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
@@ -11,17 +12,23 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hyperlink.server.AuthSetupForMock;
+import com.hyperlink.server.domain.auth.token.exception.TokenNotExistsException;
+import com.hyperlink.server.domain.content.dto.ContentResponse;
+import com.hyperlink.server.domain.content.dto.GetContentsCommonResponse;
+import com.hyperlink.server.domain.content.dto.RecommendationCompanyResponse;
 import com.hyperlink.server.domain.creator.exception.CreatorNotFoundException;
 import com.hyperlink.server.domain.member.exception.MemberNotFoundException;
 import com.hyperlink.server.domain.subscription.application.SubscriptionService;
 import com.hyperlink.server.domain.subscription.controller.SubscriptionController;
 import com.hyperlink.server.domain.subscription.dto.SubscribeResponse;
+import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -32,11 +39,14 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 
 @WebMvcTest(SubscriptionController.class)
 @MockBean(JpaMetamodelMappingContext.class)
@@ -147,7 +157,7 @@ public class SubscriptionControllerTest extends AuthSetupForMock {
               .andExpect(status().isNotFound())
               .andDo(print())
               .andExpect(response -> Assertions.assertTrue(
-                      response.getResolvedException() instanceof MemberNotFoundException));
+                  response.getResolvedException() instanceof MemberNotFoundException));
         }
 
         @Test
@@ -174,4 +184,234 @@ public class SubscriptionControllerTest extends AuthSetupForMock {
     }
   }
 
+  @Nested
+  @DisplayName("구독 피드 조회 API는")
+  class SubscriptionCreatorContentsRetrievalTest {
+
+    private GetContentsCommonResponse setUpForRetrieval() {
+      List<RecommendationCompanyResponse> recommendationCompanyResponses = List.of(
+          new RecommendationCompanyResponse("네이버", "https://naverlogo.com"));
+      List<RecommendationCompanyResponse> recommendationCompanyResponses2 = List.of(
+          new RecommendationCompanyResponse("네이버", "https://naverlogo.com"),
+          new RecommendationCompanyResponse("카카오", "https://kakaologo.com"));
+      ContentResponse contentResponse = new ContentResponse(1L, "개발자의 삶", "개발왕김딴딴", 2L,
+          "https://img1.com", "https://okky.kr/articles/503803", 4,
+          100, false, false, "2023-02-17T12:30.334", recommendationCompanyResponses);
+      ContentResponse contentResponse2 = new ContentResponse(2L, "당신은 개발자가 맞는가?", "개발왕김딴딴", 2L,
+          "https://img2.com", "https://okky.kr/articles/503343", 1,
+          35, false, false, "2023-02-17T12:30.334", recommendationCompanyResponses2);
+      List<ContentResponse> contentResponses = List.of(contentResponse, contentResponse2);
+      GetContentsCommonResponse getContentsCommonResponse = new GetContentsCommonResponse(
+          contentResponses, true);
+      return getContentsCommonResponse;
+    }
+
+    @Nested
+    @DisplayName("카테고리 별 조회 시")
+    class RetrievalByCategory {
+
+      @BeforeEach
+      void setUp() {
+        authSetup();
+      }
+
+      @Nested
+      @DisplayName("[성공]")
+      class Success {
+
+        @Test
+        @DisplayName("해당 카테고리에 속한 구독 크리에이터의 글을 볼 수 있다.")
+        void retrieveSubscribeCreatorContentsByCategory() throws Exception {
+          String page = "0";
+          String size = "10";
+
+          GetContentsCommonResponse getContentsCommonResponse = setUpForRetrieval();
+
+          Long memberId = 1L;
+          String category = "개발";
+          Pageable pageable = PageRequest.of(Integer.parseInt(page), Integer.parseInt(size));
+
+          doReturn(getContentsCommonResponse)
+              .when(subscriptionService).retrieveSubscribedCreatorsContentsByCategoryId(memberId,
+                  category, pageable);
+
+          mockMvc.perform(
+                  get("/subscriptions/contents")
+                      .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                      .param("page", page)
+                      .param("size", size)
+                      .param("category", category)
+                      .characterEncoding("UTF-8"))
+              .andExpect(status().isOk())
+              .andDo(print())
+              .andDo(document("SubscriptionControllerTest/retrieveByCategory",
+                  preprocessRequest(prettyPrint()),
+                  preprocessResponse(prettyPrint()),
+                  requestHeaders(
+                      headerWithName(HttpHeaders.AUTHORIZATION).description("AccessToken")
+                  ),
+                  responseFields(
+                      fieldWithPath("contents.[].contentId").type(JsonFieldType.NUMBER)
+                          .description("컨텐츠 id"),
+                      fieldWithPath("contents.[].title").type(JsonFieldType.STRING)
+                          .description("컨텐츠 제목"),
+                      fieldWithPath("contents.[].creatorName").type(JsonFieldType.STRING)
+                          .description("크리에이터 이름"),
+                      fieldWithPath("contents.[].creatorId").type(JsonFieldType.NUMBER)
+                          .description("크리에이터 id"),
+                      fieldWithPath("contents.[].contentImgUrl").type(JsonFieldType.STRING)
+                          .description("컨텐츠 이미지 URL"),
+                      fieldWithPath("contents.[].link").type(JsonFieldType.STRING)
+                          .description("컨텐츠 연결 외부 링크"),
+                      fieldWithPath("contents.[].likeCount").type(JsonFieldType.NUMBER)
+                          .description("좋아요 개수"),
+                      fieldWithPath("contents.[].viewCount").type(JsonFieldType.NUMBER)
+                          .description("조회수 개수"),
+                      fieldWithPath("contents.[].isBookmarked").type(JsonFieldType.BOOLEAN)
+                          .description("북마크 여부"),
+                      fieldWithPath("contents.[].isLiked").type(JsonFieldType.BOOLEAN)
+                          .description("좋아요 여부"),
+                      fieldWithPath("contents.[].createdAt").type(JsonFieldType.STRING)
+                          .description("컨텐츠 생성 날짜"),
+                      fieldWithPath("contents.[].recommendations").type(
+                          JsonFieldType.ARRAY).description("추천 배열"),
+                      fieldWithPath("contents.[].recommendations.[].bannerName").type(
+                          JsonFieldType.STRING).description("배너명"),
+                      fieldWithPath(
+                          "contents.[].recommendations.[].bannerLogoImgUrl").type(
+                          JsonFieldType.STRING).description("배너 로고 URL"),
+                      fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN)
+                          .description("다음 페이지 존재여부")
+                  )
+              ));
+        }
+      }
+
+      @Nested
+      @DisplayName("[실패]")
+      class Fail {
+        @Test
+        @DisplayName("요청 파라미터가 누락될 경우 MissingServletRequestParameterException이 발생한다.")
+        void retrieveSubscribeCreatorContentsByCategory() throws Exception {
+          String page = null;
+          String size = null;
+          String category = null;
+
+          mockMvc.perform(
+                  get("/subscriptions/contents")
+                      .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                      .param("page", page)
+                      .param("size", size)
+                      .param("category", category)
+                      .characterEncoding("UTF-8"))
+              .andExpect(status().isBadRequest())
+              .andExpect(
+                  response -> Assertions.assertTrue(
+                      response.getResolvedException() instanceof MissingServletRequestParameterException));
+
+        }
+      }
+    }
+
+    @Nested
+    @DisplayName("전체 카테고리 조회 시")
+    class RetrievalForAllCategory {
+
+      @BeforeEach
+      void setUp() {
+        authSetup();
+      }
+
+      @Nested
+      @DisplayName("[성공]")
+      class Success {
+
+        @Test
+        @DisplayName("구독 크리에이터의 모든 카테고리에 대한 글을 조회할 수 있다.")
+        void retrieveSubscribedCreatorsAllCategoryContents() throws Exception {
+          String page = "0";
+          String size = "10";
+          GetContentsCommonResponse getContentsCommonResponse = setUpForRetrieval();
+          Long memberId = 1L;
+          Pageable pageable = PageRequest.of(Integer.parseInt(page), Integer.parseInt(size));
+
+          doReturn(getContentsCommonResponse)
+              .when(subscriptionService).retrieveSubscribedCreatorsContentsForAllCategories(memberId,
+                  pageable);
+
+          mockMvc.perform(
+                  get("/subscriptions/contents/all")
+                      .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                      .param("page", page)
+                      .param("size", size)
+                      .characterEncoding("UTF-8"))
+              .andExpect(status().isOk())
+              .andDo(print())
+              .andDo(document("SubscriptionControllerTest/retrieveAllCategory",
+                  preprocessRequest(prettyPrint()),
+                  preprocessResponse(prettyPrint()),
+                  requestHeaders(
+                      headerWithName(HttpHeaders.AUTHORIZATION).description("AccessToken")
+                  ),
+                  responseFields(
+                      fieldWithPath("contents.[].contentId").type(JsonFieldType.NUMBER)
+                          .description("컨텐츠 id"),
+                      fieldWithPath("contents.[].title").type(JsonFieldType.STRING)
+                          .description("컨텐츠 제목"),
+                      fieldWithPath("contents.[].creatorName").type(JsonFieldType.STRING)
+                          .description("크리에이터 이름"),
+                      fieldWithPath("contents.[].creatorId").type(JsonFieldType.NUMBER)
+                          .description("크리에이터 id"),
+                      fieldWithPath("contents.[].contentImgUrl").type(JsonFieldType.STRING)
+                          .description("컨텐츠 이미지 URL"),
+                      fieldWithPath("contents.[].link").type(JsonFieldType.STRING)
+                          .description("컨텐츠 연결 외부 링크"),
+                      fieldWithPath("contents.[].likeCount").type(JsonFieldType.NUMBER)
+                          .description("좋아요 개수"),
+                      fieldWithPath("contents.[].viewCount").type(JsonFieldType.NUMBER)
+                          .description("조회수 개수"),
+                      fieldWithPath("contents.[].isBookmarked").type(JsonFieldType.BOOLEAN)
+                          .description("북마크 여부"),
+                      fieldWithPath("contents.[].isLiked").type(JsonFieldType.BOOLEAN)
+                          .description("좋아요 여부"),
+                      fieldWithPath("contents.[].createdAt").type(JsonFieldType.STRING)
+                          .description("컨텐츠 생성 날짜"),
+                      fieldWithPath("contents.[].recommendations").type(
+                          JsonFieldType.ARRAY).description("추천 배열"),
+                      fieldWithPath("contents.[].recommendations.[].bannerName").type(
+                          JsonFieldType.STRING).description("배너명"),
+                      fieldWithPath(
+                          "contents.[].recommendations.[].bannerLogoImgUrl").type(
+                          JsonFieldType.STRING).description("배너 로고 URL"),
+                      fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN)
+                          .description("다음 페이지 존재여부")
+                  )
+              ));
+        }
+      }
+
+      @Nested
+      @DisplayName("[실패]")
+      class Fail {
+        @Test
+        @DisplayName("요청 파라미터가 누락될 경우 MissingServletRequestParameterException이 발생한다.")
+        void retrieveSubscribeCreatorContentsByCategory() throws Exception {
+          String page = null;
+          String size = null;
+
+          mockMvc.perform(
+                  get("/subscriptions/contents/all")
+                      .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                      .param("page", page)
+                      .param("size", size)
+                      .characterEncoding("UTF-8"))
+              .andExpect(status().isBadRequest())
+              .andExpect(
+                  response -> Assertions.assertTrue(
+                      response.getResolvedException() instanceof MissingServletRequestParameterException));
+
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
### 변경 내용 요약
- 구독 피드 탭에 들어갈 구독한 크리에이터가 작성한 글을 카테고리별, 전체카테고리로 조회하기 기능을 구현

### 작업한 내용
- SubscriptionService에 조회 서비스 코드 로직 작성
    - 그에 따른 ContentRepositoryCusom QueryDsl 코드 추가
- 컨트롤러, 서비스 통합 테스트 작성

### 기타사항
- 전체 카테고리의 경우 infrastructure 계층인 repository 계층에서 도메인 로직(**0번일 때 전체 카테고리로 조회하기**)를 알고 있는 것이 좋지 않은 것으로 판단해, 따로 uri를 두어 /contents/all 같은 방식으로 만들었습니다.

close #160
