### PR TITLE
[#129] 데일리브리핑 API 구현 및 테스트 코드 작성

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -75,6 +75,10 @@ operation::SubscriptionControllerTest/retrieveByCategory[snippets='http-request,
 === 구독 피드 전체 카테고리 조회
 operation::SubscriptionControllerTest/retrieveAllCategory[snippets='http-request,http-response']
 
+== Daily-Briefing
+=== 데일리 브리핑 조회
+operation::DailyBriefingControllerTest/getDailyBriefing[snippets='http-request,http-response']
+
 == Admin
 
 === 크리에이터 삭제

--- a/src/main/java/com/hyperlink/server/ServerApplication.java
+++ b/src/main/java/com/hyperlink/server/ServerApplication.java
@@ -3,8 +3,10 @@ package com.hyperlink.server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class ServerApplication {
 

--- a/src/main/java/com/hyperlink/server/domain/category/domain/CategoryRepository.java
+++ b/src/main/java/com/hyperlink/server/domain/category/domain/CategoryRepository.java
@@ -11,4 +11,7 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
   @Query("select c.id from Category c")
   List<Long> findAllCategoryIds();
+
+  @Override
+  List<Category> findAll();
 }

--- a/src/main/java/com/hyperlink/server/domain/category/domain/vo/CategoryType.java
+++ b/src/main/java/com/hyperlink/server/domain/category/domain/vo/CategoryType.java
@@ -1,0 +1,28 @@
+package com.hyperlink.server.domain.category.domain.vo;
+
+import com.hyperlink.server.domain.category.exception.CategoryNotFoundException;
+import java.util.stream.Stream;
+
+public enum CategoryType {
+
+  DEVELOP("develop"),
+  BEAUTY("beauty"),
+  FINANCE("finance");
+
+  final String requestParamName;
+
+  CategoryType(String requestParamName) {
+    this.requestParamName = requestParamName;
+  }
+
+  public String getRequestParamName() {
+    return requestParamName;
+  }
+
+  public static CategoryType of(String name) {
+    return Stream.of(CategoryType.values())
+        .filter(categoryType -> categoryType.requestParamName.equals(name))
+        .findFirst()
+        .orElseThrow(CategoryNotFoundException::new);
+  }
+}

--- a/src/main/java/com/hyperlink/server/domain/content/controller/ContentConsumer.java
+++ b/src/main/java/com/hyperlink/server/domain/content/controller/ContentConsumer.java
@@ -21,7 +21,7 @@ public class ContentConsumer {
   public void handler(String message) throws JsonProcessingException {
     ContentEnrollResponse contentEnrollResponse = objectMapper.readValue(message,
         ContentEnrollResponse.class);
-//    contentService.insertContent(contentEnrollResponse);
+    contentService.insertContent(contentEnrollResponse);
     log.info("GET MESSAGE FROM RABBIT MQ! data : {}", contentEnrollResponse);
   }
 }

--- a/src/main/java/com/hyperlink/server/domain/content/controller/ContentConsumer.java
+++ b/src/main/java/com/hyperlink/server/domain/content/controller/ContentConsumer.java
@@ -21,7 +21,7 @@ public class ContentConsumer {
   public void handler(String message) throws JsonProcessingException {
     ContentEnrollResponse contentEnrollResponse = objectMapper.readValue(message,
         ContentEnrollResponse.class);
-    contentService.insertContent(contentEnrollResponse);
+//    contentService.insertContent(contentEnrollResponse);
     log.info("GET MESSAGE FROM RABBIT MQ! data : {}", contentEnrollResponse);
   }
 }

--- a/src/main/java/com/hyperlink/server/domain/content/controller/ContentController.java
+++ b/src/main/java/com/hyperlink/server/domain/content/controller/ContentController.java
@@ -36,8 +36,7 @@ public class ContentController {
   @ResponseStatus(HttpStatus.OK)
   public PatchInquiryResponse addViewOfContent(@LoginMemberId Optional<Long> optionalMemberId,
       @PathVariable("contentId") long contentId) {
-//    contentService.addView(optionalMemberId, contentId);
-    contentService.addView(Optional.of(1992L), contentId);
+    contentService.addView(optionalMemberId, contentId);
     int viewCount = contentService.getViewCount(contentId);
     return new PatchInquiryResponse(viewCount);
   }

--- a/src/main/java/com/hyperlink/server/domain/content/controller/ContentController.java
+++ b/src/main/java/com/hyperlink/server/domain/content/controller/ContentController.java
@@ -9,21 +9,18 @@ import com.hyperlink.server.domain.content.exception.CategoryAndCreatorIdConstra
 import com.hyperlink.server.domain.member.exception.MemberNotFoundException;
 import com.hyperlink.server.global.config.LoginMemberId;
 import java.util.Optional;
-import javax.validation.ConstraintViolationException;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -39,7 +36,8 @@ public class ContentController {
   @ResponseStatus(HttpStatus.OK)
   public PatchInquiryResponse addViewOfContent(@LoginMemberId Optional<Long> optionalMemberId,
       @PathVariable("contentId") long contentId) {
-    contentService.addView(optionalMemberId, contentId);
+//    contentService.addView(optionalMemberId, contentId);
+    contentService.addView(Optional.of(1992L), contentId);
     int viewCount = contentService.getViewCount(contentId);
     return new PatchInquiryResponse(viewCount);
   }

--- a/src/main/java/com/hyperlink/server/domain/content/domain/ContentRepository.java
+++ b/src/main/java/com/hyperlink/server/domain/content/domain/ContentRepository.java
@@ -1,6 +1,7 @@
 package com.hyperlink.server.domain.content.domain;
 
 import com.hyperlink.server.domain.content.domain.entity.Content;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -16,4 +17,6 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
   List<Content> findAllByCreatorName(String creatorName);
 
   boolean existsByLink(String link);
+
+  Integer countByCreatedAtAfter(LocalDateTime date);
 }

--- a/src/main/java/com/hyperlink/server/domain/dailyBriefing/DailyBriefingScheduler.java
+++ b/src/main/java/com/hyperlink/server/domain/dailyBriefing/DailyBriefingScheduler.java
@@ -1,0 +1,30 @@
+package com.hyperlink.server.domain.dailyBriefing;
+
+import com.hyperlink.server.domain.dailyBriefing.application.DailyBriefingService;
+import com.hyperlink.server.domain.dailyBriefing.dto.GetDailyBriefingResponse;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class DailyBriefingScheduler {
+
+  private final DailyBriefingService dailyBriefingService;
+  private final RedisTemplate<String, GetDailyBriefingResponse> dailyBriefingResponseRedisTemplate;
+
+  @Scheduled(cron = "0 0 0-23 * * *", zone = "Asia/Seoul")
+  void createDailyBriefing() {
+    log.info("데일리브리핑 스케쥴러 실행");
+    GetDailyBriefingResponse dailyBriefing = dailyBriefingService.getDailyBriefing(
+        LocalDateTime.now());
+
+    dailyBriefingResponseRedisTemplate.opsForHash().put("daily-briefing", dailyBriefing.standardTime(), dailyBriefing);
+    log.info("데일리브리핑 스케쥴러 완료");
+  }
+
+}

--- a/src/main/java/com/hyperlink/server/domain/dailyBriefing/DailyBriefingScheduler.java
+++ b/src/main/java/com/hyperlink/server/domain/dailyBriefing/DailyBriefingScheduler.java
@@ -20,7 +20,7 @@ public class DailyBriefingScheduler {
   @Scheduled(cron = "0 0 0-23 * * *", zone = "Asia/Seoul")
   void createDailyBriefing() {
     log.info("데일리브리핑 스케쥴러 실행");
-    GetDailyBriefingResponse dailyBriefing = dailyBriefingService.getDailyBriefing(
+    GetDailyBriefingResponse dailyBriefing = dailyBriefingService.createDailyBriefing(
         LocalDateTime.now());
 
     dailyBriefingResponseRedisTemplate.opsForHash().put("daily-briefing", dailyBriefing.standardTime(), dailyBriefing);

--- a/src/main/java/com/hyperlink/server/domain/dailyBriefing/application/DailyBriefingService.java
+++ b/src/main/java/com/hyperlink/server/domain/dailyBriefing/application/DailyBriefingService.java
@@ -1,0 +1,115 @@
+package com.hyperlink.server.domain.dailyBriefing.application;
+
+import com.hyperlink.server.domain.category.domain.CategoryRepository;
+import com.hyperlink.server.domain.category.domain.entity.Category;
+import com.hyperlink.server.domain.category.domain.vo.CategoryType;
+import com.hyperlink.server.domain.content.domain.ContentRepository;
+import com.hyperlink.server.domain.dailyBriefing.domain.vo.CountStatisticsByCategory;
+import com.hyperlink.server.domain.dailyBriefing.dto.DailyBriefing;
+import com.hyperlink.server.domain.dailyBriefing.dto.GetDailyBriefingResponse;
+import com.hyperlink.server.domain.dailyBriefing.dto.StatisticsByCategoryResponse;
+import com.hyperlink.server.domain.dailyBriefing.infrastructure.DailyBriefingRepositoryCustom;
+import com.hyperlink.server.domain.member.domain.MemberRepository;
+import com.hyperlink.server.domain.memberHistory.domain.MemberHistoryRepository;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DailyBriefingService {
+
+  public static final int STANDARD_HOUR = 24;
+
+  private final MemberRepository memberRepository;
+  private final MemberHistoryRepository memberHistoryRepository;
+  private final ContentRepository contentRepository;
+  private final CategoryRepository categoryRepository;
+  private final DailyBriefingRepositoryCustom dailyBriefingRepositoryCustom;
+
+  public GetDailyBriefingResponse getDailyBriefing(LocalDateTime standardTime) {
+    LocalDateTime pastOneDay = standardTime.minusHours(STANDARD_HOUR);
+
+    Integer memberIncrease = memberRepository.countByCreatedAtAfter(pastOneDay);
+    List<String> findCategoryNameOfHistoryPastOneDayAfter = memberHistoryRepository.findAllByCreatedAtAfter(
+        pastOneDay);
+    int viewIncrease = findCategoryNameOfHistoryPastOneDayAfter.size();
+    List<StatisticsByCategoryResponse> viewByCategories = getViewAndRankingByCategories(
+        findCategoryNameOfHistoryPastOneDayAfter);
+
+    LocalDateTime startOfToday = standardTime.toLocalDate().atStartOfDay();
+    Integer contentIncrease = contentRepository.countByCreatedAtAfter(startOfToday);
+    List<StatisticsByCategoryResponse> memberCountByAttentionCategories = getMemberCountAndRankingByAttentionCategories();
+
+    DailyBriefing dailyBriefing = new DailyBriefing(memberIncrease, viewIncrease, viewByCategories,
+        contentIncrease, memberCountByAttentionCategories);
+    return new GetDailyBriefingResponse(
+        standardTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH")), dailyBriefing);
+  }
+
+  public List<StatisticsByCategoryResponse> getViewAndRankingByCategories(
+      List<String> categoryNameOfHistoryPastOneDayAfter) {
+    Map<String, CountStatisticsByCategory> viewCountStatisticsByCategoryHashMap = new HashMap<>();
+    for (CategoryType categoryType : CategoryType.values()) {
+      CountStatisticsByCategory countStatisticsByCategory = new CountStatisticsByCategory(
+          categoryType);
+      viewCountStatisticsByCategoryHashMap.put(categoryType.getRequestParamName(),
+          countStatisticsByCategory);
+    }
+
+    for (String categoryName : categoryNameOfHistoryPastOneDayAfter) {
+      viewCountStatisticsByCategoryHashMap.get(categoryName).addViewCountStatistics();
+    }
+
+    return includeCalculateRankingAndCreateStatisticsByCategoryResponse(viewCountStatisticsByCategoryHashMap);
+  }
+
+  public List<StatisticsByCategoryResponse> getMemberCountAndRankingByAttentionCategories() {
+    Map<String, CountStatisticsByCategory> memberCountStatisticsByCategoryHashMap = new HashMap<>();
+
+    List<Category> allCategory = categoryRepository.findAll();
+    for (Category category : allCategory) {
+      long memberCount = dailyBriefingRepositoryCustom.getMemberCountByAttentionCategories(
+          category.getId()).orElseGet(() -> 0L);
+      CountStatisticsByCategory countStatisticsByCategory = new CountStatisticsByCategory(
+          CategoryType.of(category.getName()), memberCount);
+      memberCountStatisticsByCategoryHashMap.put(category.getName(), countStatisticsByCategory);
+    }
+
+    return includeCalculateRankingAndCreateStatisticsByCategoryResponse(memberCountStatisticsByCategoryHashMap);
+  }
+
+  public List<StatisticsByCategoryResponse> includeCalculateRankingAndCreateStatisticsByCategoryResponse(Map<String, CountStatisticsByCategory> countStatisticsByCategoryHashMap) {
+    List<CountStatisticsByCategory> countStatisticsByCategoriesForRanking = new ArrayList<>(
+        countStatisticsByCategoryHashMap.values());
+    calculateRanking(countStatisticsByCategoriesForRanking);
+
+    List<StatisticsByCategoryResponse> statisticsByCategories = new ArrayList<>();
+    countStatisticsByCategoryHashMap.forEach((categoryName, countStatisticsByCategory) -> {
+      StatisticsByCategoryResponse statisticsByCategoryResponse = new StatisticsByCategoryResponse(
+          categoryName, countStatisticsByCategory.getCount(),
+          countStatisticsByCategory.getRanking());
+      statisticsByCategories.add(statisticsByCategoryResponse);
+    });
+    return statisticsByCategories;
+  }
+
+  public void calculateRanking(
+      List<CountStatisticsByCategory> countStatisticsByCategorylist) {
+    int categorySize = countStatisticsByCategorylist.size();
+
+    for (int i = 0; i < categorySize; i++) {
+      for (int j = 0; j < categorySize; j++) {
+        if (countStatisticsByCategorylist.get(i).getCount() < countStatisticsByCategorylist.get(j)
+            .getCount()) {
+          countStatisticsByCategorylist.get(i).upRanking();
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/com/hyperlink/server/domain/dailyBriefing/controller/DailyBriefingController.java
+++ b/src/main/java/com/hyperlink/server/domain/dailyBriefing/controller/DailyBriefingController.java
@@ -1,10 +1,9 @@
 package com.hyperlink.server.domain.dailyBriefing.controller;
 
+import com.hyperlink.server.domain.dailyBriefing.application.DailyBriefingService;
 import com.hyperlink.server.domain.dailyBriefing.dto.GetDailyBriefingResponse;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -14,14 +13,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class DailyBriefingController {
 
-  private final RedisTemplate<String, GetDailyBriefingResponse> dailyBriefingResponseRedisTemplate;
+  private final DailyBriefingService dailyBriefingService;
 
   @GetMapping("/daily-briefing")
   @ResponseStatus(HttpStatus.OK)
   public GetDailyBriefingResponse getDailyBriefing() {
     LocalDateTime now = LocalDateTime.now();
-    String standardTime = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH"));
-    return (GetDailyBriefingResponse) dailyBriefingResponseRedisTemplate.opsForHash()
-        .get("daily-briefing", standardTime);
+    return dailyBriefingService.getDailyBriefingResponse(now);
   }
 }

--- a/src/main/java/com/hyperlink/server/domain/dailyBriefing/controller/DailyBriefingController.java
+++ b/src/main/java/com/hyperlink/server/domain/dailyBriefing/controller/DailyBriefingController.java
@@ -1,0 +1,27 @@
+package com.hyperlink.server.domain.dailyBriefing.controller;
+
+import com.hyperlink.server.domain.dailyBriefing.dto.GetDailyBriefingResponse;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class DailyBriefingController {
+
+  private final RedisTemplate<String, GetDailyBriefingResponse> dailyBriefingResponseRedisTemplate;
+
+  @GetMapping("/daily-briefing")
+  @ResponseStatus(HttpStatus.OK)
+  public GetDailyBriefingResponse getDailyBriefing() {
+    LocalDateTime now = LocalDateTime.now();
+    String standardTime = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH"));
+    return (GetDailyBriefingResponse) dailyBriefingResponseRedisTemplate.opsForHash()
+        .get("daily-briefing", standardTime);
+  }
+}

--- a/src/main/java/com/hyperlink/server/domain/dailyBriefing/domain/vo/CountStatisticsByCategory.java
+++ b/src/main/java/com/hyperlink/server/domain/dailyBriefing/domain/vo/CountStatisticsByCategory.java
@@ -1,0 +1,55 @@
+package com.hyperlink.server.domain.dailyBriefing.domain.vo;
+
+import com.hyperlink.server.domain.category.domain.vo.CategoryType;
+import java.util.Objects;
+import lombok.Getter;
+
+@Getter
+public class CountStatisticsByCategory {
+
+  private static final int RANK_INIT = 1;
+
+  CategoryType categoryType;
+  long count;
+  int ranking;
+  StatisticsType statisticsType;
+
+  public CountStatisticsByCategory(CategoryType categoryType) {
+    this.categoryType = categoryType;
+    this.count = 0;
+    this.ranking = RANK_INIT;
+    this.statisticsType = StatisticsType.VIEW_COUNT;
+  }
+
+  public CountStatisticsByCategory(CategoryType categoryType, long count) {
+    this.categoryType = categoryType;
+    this.count = count;
+    this.ranking = RANK_INIT;
+    this.statisticsType = StatisticsType.MEMBER_COUNT;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof CountStatisticsByCategory that)) {
+      return false;
+    }
+    return getCategoryType() == that.getCategoryType()
+        && getStatisticsType() == that.getStatisticsType();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getCategoryType(), getStatisticsType());
+  }
+
+  public void addViewCountStatistics() {
+    this.count++;
+  }
+
+  public void upRanking() {
+    this.ranking++;
+  }
+}

--- a/src/main/java/com/hyperlink/server/domain/dailyBriefing/domain/vo/StatisticsType.java
+++ b/src/main/java/com/hyperlink/server/domain/dailyBriefing/domain/vo/StatisticsType.java
@@ -1,0 +1,6 @@
+package com.hyperlink.server.domain.dailyBriefing.domain.vo;
+
+public enum StatisticsType {
+
+  VIEW_COUNT, MEMBER_COUNT
+}

--- a/src/main/java/com/hyperlink/server/domain/dailyBriefing/dto/DailyBriefing.java
+++ b/src/main/java/com/hyperlink/server/domain/dailyBriefing/dto/DailyBriefing.java
@@ -1,0 +1,14 @@
+package com.hyperlink.server.domain.dailyBriefing.dto;
+
+import java.io.Serializable;
+import java.util.List;
+
+public record DailyBriefing(
+    int memberIncrease,
+    int viewIncrease,
+    List<StatisticsByCategoryResponse> viewByCategories,
+    int contentIncrease,
+    List<StatisticsByCategoryResponse> memberCountByAttentionCategories
+) implements Serializable {
+
+}

--- a/src/main/java/com/hyperlink/server/domain/dailyBriefing/dto/GetDailyBriefingResponse.java
+++ b/src/main/java/com/hyperlink/server/domain/dailyBriefing/dto/GetDailyBriefingResponse.java
@@ -1,0 +1,10 @@
+package com.hyperlink.server.domain.dailyBriefing.dto;
+
+import java.io.Serializable;
+
+public record GetDailyBriefingResponse(
+    String standardTime,
+    DailyBriefing dailyBriefing
+) implements Serializable {
+
+}

--- a/src/main/java/com/hyperlink/server/domain/dailyBriefing/dto/StatisticsByCategoryResponse.java
+++ b/src/main/java/com/hyperlink/server/domain/dailyBriefing/dto/StatisticsByCategoryResponse.java
@@ -1,0 +1,11 @@
+package com.hyperlink.server.domain.dailyBriefing.dto;
+
+import java.io.Serializable;
+
+public record StatisticsByCategoryResponse(
+    String categoryName,
+    long count,
+    int ranking
+) implements Serializable {
+
+}

--- a/src/main/java/com/hyperlink/server/domain/dailyBriefing/infrastructure/DailyBriefingRepositoryCustom.java
+++ b/src/main/java/com/hyperlink/server/domain/dailyBriefing/infrastructure/DailyBriefingRepositoryCustom.java
@@ -1,0 +1,27 @@
+package com.hyperlink.server.domain.dailyBriefing.infrastructure;
+
+import static com.hyperlink.server.domain.attentionCategory.domain.entity.QAttentionCategory.attentionCategory;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class DailyBriefingRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  public Optional<Long> getMemberCountByAttentionCategories(Long categoryId) {
+    return Optional.ofNullable(queryFactory.select(attentionCategory.count())
+        .from(attentionCategory)
+        .where(eqCategoryId(categoryId))
+        .fetchOne());
+  }
+
+  private BooleanExpression eqCategoryId(Long categoryId) {
+    return attentionCategory.category.id.eq(categoryId);
+  }
+}

--- a/src/main/java/com/hyperlink/server/domain/member/domain/MemberRepository.java
+++ b/src/main/java/com/hyperlink/server/domain/member/domain/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.hyperlink.server.domain.member.domain;
 
 import com.hyperlink.server.domain.member.domain.entity.Member;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,5 +10,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
   Boolean existsByEmail(String email);
 
   Optional<Member> findByEmail(String email);
+
+  Integer countByCreatedAtAfter(LocalDateTime dateTime);
 
 }

--- a/src/main/java/com/hyperlink/server/domain/memberHistory/domain/MemberHistoryRepository.java
+++ b/src/main/java/com/hyperlink/server/domain/memberHistory/domain/MemberHistoryRepository.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberHistoryRepository extends JpaRepository<MemberHistory, Long> {
 
@@ -15,4 +16,6 @@ public interface MemberHistoryRepository extends JpaRepository<MemberHistory, Lo
 
   Long countByCreatedAtAfter(LocalDateTime dateTime);
 
+  @Query("select ca.name from MemberHistory mh join mh.content con join con.category ca")
+  List<String> findAllByCreatedAtAfter(LocalDateTime dateTime);
 }

--- a/src/main/java/com/hyperlink/server/global/config/RedisConfig.java
+++ b/src/main/java/com/hyperlink/server/global/config/RedisConfig.java
@@ -1,0 +1,36 @@
+package com.hyperlink.server.global.config;
+
+import com.hyperlink.server.domain.dailyBriefing.dto.GetDailyBriefingResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+  @Value("${spring.redis.host}")
+  private String host;
+
+  @Value("${spring.redis.port}")
+  private int port;
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    return new LettuceConnectionFactory(host, port);
+  }
+
+  @Bean
+  public RedisTemplate<String, GetDailyBriefingResponse> redisTemplate() {
+    RedisTemplate<String, GetDailyBriefingResponse> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(
+        new Jackson2JsonRedisSerializer<>(GetDailyBriefingResponse.class));
+    redisTemplate.setConnectionFactory(redisConnectionFactory());
+    return redisTemplate;
+  }
+}

--- a/src/main/java/com/hyperlink/server/global/config/RedisConfig.java
+++ b/src/main/java/com/hyperlink/server/global/config/RedisConfig.java
@@ -25,7 +25,7 @@ public class RedisConfig {
   }
 
   @Bean
-  public RedisTemplate<String, GetDailyBriefingResponse> redisTemplate() {
+  public RedisTemplate<String, GetDailyBriefingResponse> dailyBriefingRedisTemplate() {
     RedisTemplate<String, GetDailyBriefingResponse> redisTemplate = new RedisTemplate<>();
     redisTemplate.setKeySerializer(new StringRedisSerializer());
     redisTemplate.setValueSerializer(

--- a/src/test/java/com/hyperlink/server/dailyBriefing/application/DailyBriefingServiceUnitTest.java
+++ b/src/test/java/com/hyperlink/server/dailyBriefing/application/DailyBriefingServiceUnitTest.java
@@ -94,7 +94,7 @@ public class DailyBriefingServiceUnitTest {
       doReturn(List.of(new StatisticsByCategoryResponse("develop", 13, 3))).when(
           dailyBriefingService).getMemberCountAndRankingByAttentionCategories();
 
-      dailyBriefingService.getDailyBriefing(LocalDateTime.now());
+      dailyBriefingService.createDailyBriefing(LocalDateTime.now());
 
       verify(memberRepository, times(1)).countByCreatedAtAfter(any());
       verify(memberHistoryRepository, times(1)).findAllByCreatedAtAfter(any());

--- a/src/test/java/com/hyperlink/server/dailyBriefing/application/DailyBriefingServiceUnitTest.java
+++ b/src/test/java/com/hyperlink/server/dailyBriefing/application/DailyBriefingServiceUnitTest.java
@@ -1,0 +1,241 @@
+package com.hyperlink.server.dailyBriefing.application;
+
+import static com.hyperlink.server.domain.category.domain.vo.CategoryType.BEAUTY;
+import static com.hyperlink.server.domain.category.domain.vo.CategoryType.DEVELOP;
+import static com.hyperlink.server.domain.category.domain.vo.CategoryType.FINANCE;
+import static com.hyperlink.server.domain.category.domain.vo.CategoryType.of;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.hyperlink.server.domain.category.domain.CategoryRepository;
+import com.hyperlink.server.domain.category.domain.entity.Category;
+import com.hyperlink.server.domain.content.domain.ContentRepository;
+import com.hyperlink.server.domain.dailyBriefing.application.DailyBriefingService;
+import com.hyperlink.server.domain.dailyBriefing.domain.vo.CountStatisticsByCategory;
+import com.hyperlink.server.domain.dailyBriefing.dto.DailyBriefing;
+import com.hyperlink.server.domain.dailyBriefing.dto.GetDailyBriefingResponse;
+import com.hyperlink.server.domain.dailyBriefing.dto.StatisticsByCategoryResponse;
+import com.hyperlink.server.domain.dailyBriefing.infrastructure.DailyBriefingRepositoryCustom;
+import com.hyperlink.server.domain.member.domain.MemberRepository;
+import com.hyperlink.server.domain.memberHistory.domain.MemberHistoryRepository;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class DailyBriefingServiceUnitTest {
+
+  @Mock
+  MemberRepository memberRepository;
+  @Mock
+  MemberHistoryRepository memberHistoryRepository;
+  @Mock
+  ContentRepository contentRepository;
+  @Mock
+  CategoryRepository categoryRepository;
+  @Mock
+  DailyBriefingRepositoryCustom dailyBriefingRepositoryCustom;
+  @Spy
+  @InjectMocks
+  DailyBriefingService dailyBriefingService;
+
+  @Nested
+  @DisplayName("데일리브리핑 조회 메서드는")
+  class GetDailyBriefingUnit {
+
+    GetDailyBriefingResponse getDailyBriefingResponse;
+
+    @BeforeEach
+    void responseSetUp() {
+      LocalDateTime standardTime = LocalDateTime.now();
+      List<StatisticsByCategoryResponse> viewByCategories = List.of(
+          new StatisticsByCategoryResponse("develop", 283, 3),
+          new StatisticsByCategoryResponse("beauty", 832, 1),
+          new StatisticsByCategoryResponse("finance", 425, 2));
+      List<StatisticsByCategoryResponse> memberCountByAttentionCategories = List.of(
+          new StatisticsByCategoryResponse("develop", 13, 3),
+          new StatisticsByCategoryResponse("beauty", 92, 1),
+          new StatisticsByCategoryResponse("finance", 55, 2));
+
+      DailyBriefing dailyBriefing = new DailyBriefing(300, 1540, viewByCategories,
+          45, memberCountByAttentionCategories);
+      getDailyBriefingResponse = new GetDailyBriefingResponse(
+          standardTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")), dailyBriefing);
+    }
+
+    @Test
+    @DisplayName("총 5가지의 통계 자료를 응답한다")
+    void fourStatistics() {
+      doReturn(300).when(memberRepository).countByCreatedAtAfter(any());
+      doReturn(List.of("categoryName")).when(memberHistoryRepository)
+          .findAllByCreatedAtAfter(any());
+      doReturn(List.of(new StatisticsByCategoryResponse("develop", 283, 3))).when(
+          dailyBriefingService).getViewAndRankingByCategories(any());
+      doReturn(45).when(contentRepository).countByCreatedAtAfter(any());
+      doReturn(List.of(new StatisticsByCategoryResponse("develop", 13, 3))).when(
+          dailyBriefingService).getMemberCountAndRankingByAttentionCategories();
+
+      dailyBriefingService.getDailyBriefing(LocalDateTime.now());
+
+      verify(memberRepository, times(1)).countByCreatedAtAfter(any());
+      verify(memberHistoryRepository, times(1)).findAllByCreatedAtAfter(any());
+      verify(dailyBriefingService, times(1)).getViewAndRankingByCategories(any());
+      verify(contentRepository, times(1)).countByCreatedAtAfter(any());
+      verify(dailyBriefingService, times(1)).getMemberCountAndRankingByAttentionCategories();
+    }
+  }
+
+  @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
+  @DisplayName("getViewByCategories 메소드는")
+  class GetViewByCategoriesTest {
+
+    Stream<Arguments> createViewCountAndRanking() {
+      return Stream.of(
+          Arguments.of(DEVELOP.getRequestParamName(), 3, 1),
+          Arguments.of(BEAUTY.getRequestParamName(), 1, 2),
+          Arguments.of(FINANCE.getRequestParamName(), 1, 2)
+      );
+    }
+
+    @ParameterizedTest
+    @MethodSource("createViewCountAndRanking")
+    @DisplayName("인자로 받은 history 내역에 대해서 카테고리별 조회수, 랭킹을 계산한다")
+    void getViewByCategoriesTest(String categoryName, int view, int ranking) {
+      List<String> categoryNameOfHistoryPastOneDayAfter = List.of(DEVELOP.getRequestParamName(),
+          DEVELOP.getRequestParamName(), BEAUTY.getRequestParamName(),
+          DEVELOP.getRequestParamName(),
+          FINANCE.getRequestParamName());
+
+      List<StatisticsByCategoryResponse> viewByCategories = dailyBriefingService.getViewAndRankingByCategories(
+          categoryNameOfHistoryPastOneDayAfter);
+
+      StatisticsByCategoryResponse statisticsByCategoryResponse = viewByCategories.stream()
+          .filter(statistics -> statistics.categoryName()
+              .equals(categoryName))
+          .findFirst().orElseThrow();
+      assertThat(statisticsByCategoryResponse.count()).isEqualTo(view);
+      assertThat(statisticsByCategoryResponse.ranking()).isEqualTo(ranking);
+    }
+
+    @Test
+    @DisplayName("24시간 동안 집계된 조회내역이 없다면 모든 카테고리에 대해서 count=0, ranking=1이 반환된다")
+    void nothingHistory() {
+      List<String> categoryNameOfHistoryPastOneDayAfter = List.of();
+
+      List<StatisticsByCategoryResponse> viewByCategories = dailyBriefingService.getViewAndRankingByCategories(
+          categoryNameOfHistoryPastOneDayAfter);
+
+      for (StatisticsByCategoryResponse statisticsByCategoryResponse : viewByCategories) {
+        assertThat(statisticsByCategoryResponse.count()).isZero();
+        assertThat(statisticsByCategoryResponse.ranking()).isOne();
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("getMemberCountByAttentionCategories 메소드는")
+  class GetMemberCountByAttentionCategoriesTest {
+
+    @Test
+    @DisplayName("관심카테고리별 회원 숫자와 랭킹을 계산한다")
+    void sameMemberCountAndRankingTest() {
+      Optional<Long> optMemberCount = Optional.of(3L);
+      final int ranking = 1;
+
+      List<Category> allCategory = List.of(
+          new Category(DEVELOP.getRequestParamName()),
+          new Category(BEAUTY.getRequestParamName()),
+          new Category(FINANCE.getRequestParamName())
+      );
+
+      doReturn(allCategory).when(categoryRepository).findAll();
+      doReturn(optMemberCount).when(dailyBriefingRepositoryCustom)
+          .getMemberCountByAttentionCategories(any());
+
+      List<StatisticsByCategoryResponse> memberCountByAttentionCategories = dailyBriefingService.getMemberCountAndRankingByAttentionCategories();
+      for (StatisticsByCategoryResponse statisticsByCategoryResponse : memberCountByAttentionCategories) {
+        assertThat(statisticsByCategoryResponse.count()).isEqualTo(optMemberCount.get());
+        assertThat(statisticsByCategoryResponse.ranking()).isEqualTo(ranking);
+      }
+    }
+
+    @Test
+    @DisplayName("관심카테고리별 회원 숫자가 0일 경우 count=0을 응답한다")
+    void memberCountIsZero() {
+      Optional<Long> optMemberCount = Optional.empty();
+      final int ranking = 1;
+
+      List<Category> allCategory = List.of(
+          new Category(DEVELOP.getRequestParamName()),
+          new Category(BEAUTY.getRequestParamName()),
+          new Category(FINANCE.getRequestParamName())
+      );
+
+      doReturn(allCategory).when(categoryRepository).findAll();
+      doReturn(optMemberCount).when(dailyBriefingRepositoryCustom)
+          .getMemberCountByAttentionCategories(any());
+
+      List<StatisticsByCategoryResponse> memberCountByAttentionCategories = dailyBriefingService.getMemberCountAndRankingByAttentionCategories();
+      for (StatisticsByCategoryResponse statisticsByCategoryResponse : memberCountByAttentionCategories) {
+        assertThat(statisticsByCategoryResponse.count()).isZero();
+        assertThat(statisticsByCategoryResponse.ranking()).isEqualTo(ranking);
+      }
+    }
+  }
+
+  @Nested
+  @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+  @DisplayName("랭킹 계산 메서드는")
+  class CalculateRanking {
+
+    List<CountStatisticsByCategory> countStatisticsByCategorylist;
+
+    @BeforeEach
+    void calculateRankingTest() {
+      countStatisticsByCategorylist = List.of(
+          new CountStatisticsByCategory(of("develop"), 13),
+          new CountStatisticsByCategory(of("beauty"), 92),
+          new CountStatisticsByCategory(of("finance"), 55)
+      );
+
+      dailyBriefingService.calculateRanking(countStatisticsByCategorylist);
+    }
+
+    Stream<Arguments> createResultRanking() {
+      return Stream.of(
+          Arguments.of(0, 3),
+          Arguments.of(1, 1),
+          Arguments.of(2, 2)
+      );
+    }
+
+    @ParameterizedTest
+    @MethodSource("createResultRanking")
+    @DisplayName("CountStatisticsByCategory의 count 숫자가 높은 순서대로 랭킹을 계산하여 객체 내부에 저장한다")
+    void verifyRankingResultTest(int index, int ranking) {
+      assertThat(countStatisticsByCategorylist.get(index).getRanking()).isEqualTo(ranking);
+    }
+
+  }
+
+}

--- a/src/test/java/com/hyperlink/server/dailyBriefing/controller/DailyBriefingControllerTest.java
+++ b/src/test/java/com/hyperlink/server/dailyBriefing/controller/DailyBriefingControllerTest.java
@@ -1,0 +1,134 @@
+package com.hyperlink.server.dailyBriefing.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hyperlink.server.AuthSetupForMock;
+import com.hyperlink.server.domain.dailyBriefing.application.DailyBriefingService;
+import com.hyperlink.server.domain.dailyBriefing.controller.DailyBriefingController;
+import com.hyperlink.server.domain.dailyBriefing.dto.DailyBriefing;
+import com.hyperlink.server.domain.dailyBriefing.dto.GetDailyBriefingResponse;
+import com.hyperlink.server.domain.dailyBriefing.dto.StatisticsByCategoryResponse;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(DailyBriefingController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc
+public class DailyBriefingControllerTest extends AuthSetupForMock {
+
+  @MockBean
+  DailyBriefingService dailyBriefingService;
+  @Autowired
+  MockMvc mockMvc;
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @Nested
+  @DisplayName("데일리브리핑 조회 API는")
+  class GetDailyBriefing {
+
+    @Nested
+    @DisplayName("유효한 요청값이 들어오면")
+    class Success {
+      GetDailyBriefingResponse getDailyBriefingResponse;
+
+      @BeforeEach
+      void setUp() {
+        LocalDateTime standardTime = LocalDateTime.now();
+        List<StatisticsByCategoryResponse> viewByCategories = List.of(
+            new StatisticsByCategoryResponse("develop", 283, 3),
+            new StatisticsByCategoryResponse("beauty", 832, 1),
+            new StatisticsByCategoryResponse("finance", 425, 2));
+        List<StatisticsByCategoryResponse> memberCountByAttentionCategories = List.of(
+            new StatisticsByCategoryResponse("develop", 13, 3),
+            new StatisticsByCategoryResponse("beauty", 92, 1),
+            new StatisticsByCategoryResponse("finance", 55, 2));
+
+        DailyBriefing dailyBriefing = new DailyBriefing(300, 1540, viewByCategories,
+            45, memberCountByAttentionCategories);
+        getDailyBriefingResponse = new GetDailyBriefingResponse(
+            standardTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")), dailyBriefing);
+      }
+
+      @Test
+      @DisplayName("데일리브리핑 조회에 성공하고 OK와 데일리브리핑을 응답한다")
+      void getDailyBriefing() throws Exception {
+        doReturn(getDailyBriefingResponse).when(dailyBriefingService).getDailyBriefing(any());
+
+        mockMvc.perform(
+                get("/daily-briefing")
+            )
+            .andExpect(status().isOk())
+            .andDo(
+                document(
+                    "DailyBriefingControllerTest/getDailyBriefing",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    responseFields(
+                        fieldWithPath("standardTime").type(JsonFieldType.STRING)
+                            .description("통계 기준 시간"),
+                        fieldWithPath("dailyBriefing").type(JsonFieldType.OBJECT)
+                            .description("데일리브리핑 데이터"),
+                        fieldWithPath("dailyBriefing.memberIncrease").type(JsonFieldType.NUMBER)
+                            .description("24시간 동안 증가된 가입회원 수"),
+                        fieldWithPath("dailyBriefing.viewIncrease").type(JsonFieldType.NUMBER)
+                            .description("24시간 동안 집계된 총 조회수"),
+                        fieldWithPath("dailyBriefing.viewByCategories").type(JsonFieldType.ARRAY)
+                            .description("24시간 동안 집계된 카테고리별 조회수"),
+                        fieldWithPath("dailyBriefing.viewByCategories.[].categoryName").type(
+                                JsonFieldType.STRING)
+                            .description("카테고리 이름"),
+                        fieldWithPath("dailyBriefing.viewByCategories.[].count").type(
+                                JsonFieldType.NUMBER)
+                            .description("24시간 동안 집계된 조회수"),
+                        fieldWithPath("dailyBriefing.viewByCategories.[].ranking").type(
+                                JsonFieldType.NUMBER)
+                            .description("24시간 동안 집계된 조회수 기준 카테고리 랭킹"),
+                        fieldWithPath("dailyBriefing.contentIncrease").type(JsonFieldType.NUMBER)
+                            .description("오늘 새로 추가된 컨텐츠 수"),
+                        fieldWithPath("dailyBriefing.memberCountByAttentionCategories").type(
+                                JsonFieldType.ARRAY)
+                            .description("관심 카테고리별 고객 수"),
+                        fieldWithPath(
+                            "dailyBriefing.memberCountByAttentionCategories.[].categoryName").type(
+                                JsonFieldType.STRING)
+                            .description("카테고리 이름"),
+                        fieldWithPath(
+                            "dailyBriefing.memberCountByAttentionCategories.[].count").type(
+                                JsonFieldType.NUMBER)
+                            .description("해당 카테고리를 관심 카테고리로 설정한 고객 수"),
+                        fieldWithPath(
+                            "dailyBriefing.memberCountByAttentionCategories.[].ranking").type(
+                                JsonFieldType.NUMBER)
+                            .description("관심 카테고리별 회원 수 기준 카테고리 랭킹")
+                    )
+                )
+            );
+      }
+    }
+  }
+}

--- a/src/test/java/com/hyperlink/server/dailyBriefing/controller/DailyBriefingControllerTest.java
+++ b/src/test/java/com/hyperlink/server/dailyBriefing/controller/DailyBriefingControllerTest.java
@@ -77,7 +77,7 @@ public class DailyBriefingControllerTest extends AuthSetupForMock {
       @Test
       @DisplayName("데일리브리핑 조회에 성공하고 OK와 데일리브리핑을 응답한다")
       void getDailyBriefing() throws Exception {
-        doReturn(getDailyBriefingResponse).when(dailyBriefingService).getDailyBriefing(any());
+        doReturn(getDailyBriefingResponse).when(dailyBriefingService).createDailyBriefing(any());
 
         mockMvc.perform(
                 get("/daily-briefing")

--- a/src/test/java/com/hyperlink/server/dailyBriefing/domain/vo/CountStatisticsByCategoryTest.java
+++ b/src/test/java/com/hyperlink/server/dailyBriefing/domain/vo/CountStatisticsByCategoryTest.java
@@ -1,0 +1,78 @@
+package com.hyperlink.server.dailyBriefing.domain.vo;
+
+import static com.hyperlink.server.domain.category.domain.vo.CategoryType.BEAUTY;
+import static com.hyperlink.server.domain.category.domain.vo.CategoryType.DEVELOP;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hyperlink.server.domain.dailyBriefing.domain.vo.CountStatisticsByCategory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("CountStatisticsByCategory VO 테스트")
+public class CountStatisticsByCategoryTest {
+
+  @Nested
+  class EqualsAndHashCodeTest {
+
+    @Test
+    @DisplayName("CountStatisticsByCategory는 categoryType, statisticsType이 같을 경우 같은 객체이다")
+    void equalsAndHashCodeTest() {
+      CountStatisticsByCategory developStatisticsOne = new CountStatisticsByCategory(DEVELOP);
+      CountStatisticsByCategory developStatisticsTwo = new CountStatisticsByCategory(DEVELOP);
+
+      boolean equals = developStatisticsOne.equals(developStatisticsTwo);
+
+      assertTrue(equals);
+      assertThat(developStatisticsOne).hasSameHashCodeAs(developStatisticsTwo);
+    }
+
+    @Test
+    @DisplayName("CountStatisticsByCategory는 주소값이 같을 경우 같은 객체이다")
+    void sameObjectEqualsAndHashCodeTest() {
+      CountStatisticsByCategory developStatistics = new CountStatisticsByCategory(DEVELOP);
+
+      boolean equals = developStatistics.equals(developStatistics);
+
+      assertTrue(equals);
+      assertThat(developStatistics).hasSameHashCodeAs(developStatistics);
+    }
+
+    @Test
+    @DisplayName("CountStatisticsByCategory는 다른 객체와 equals가 false이다")
+    void differentObjectTypeTest() {
+      CountStatisticsByCategory developStatistics = new CountStatisticsByCategory(DEVELOP);
+      String developString = "develop";
+
+      boolean equals = developStatistics.equals(developString);
+
+      assertFalse(equals);
+    }
+
+    @Test
+    @DisplayName("CountStatisticsByCategory는 categoryType이 다를 경우 다른 객체이다")
+    void differentCategoryTypeTest() {
+      CountStatisticsByCategory developStatistics = new CountStatisticsByCategory(DEVELOP);
+      CountStatisticsByCategory beautyStatistics = new CountStatisticsByCategory(BEAUTY);
+
+      boolean equals = developStatistics.equals(beautyStatistics);
+
+      assertFalse(equals);
+      assertThat(developStatistics).doesNotHaveSameHashCodeAs(beautyStatistics);
+    }
+
+    @Test
+    @DisplayName("CountStatisticsByCategory는 statisticsType이 다를 경우 다른 객체이다")
+    void differentStatisticsTypeTest() {
+      CountStatisticsByCategory developStatisticsOne = new CountStatisticsByCategory(DEVELOP);
+      CountStatisticsByCategory developStatisticsTwo = new CountStatisticsByCategory(DEVELOP, 3L);
+
+      boolean equals = developStatisticsOne.equals(developStatisticsTwo);
+
+      assertFalse(equals);
+      assertThat(developStatisticsOne).doesNotHaveSameHashCodeAs(developStatisticsTwo);
+    }
+  }
+}

--- a/src/test/java/com/hyperlink/server/dailyBriefing/infrastructure/DailyBriefingRepositoryCustomTest.java
+++ b/src/test/java/com/hyperlink/server/dailyBriefing/infrastructure/DailyBriefingRepositoryCustomTest.java
@@ -1,0 +1,85 @@
+package com.hyperlink.server.dailyBriefing.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hyperlink.server.domain.attentionCategory.domain.AttentionCategoryRepository;
+import com.hyperlink.server.domain.attentionCategory.domain.entity.AttentionCategory;
+import com.hyperlink.server.domain.category.domain.CategoryRepository;
+import com.hyperlink.server.domain.category.domain.entity.Category;
+import com.hyperlink.server.domain.category.domain.vo.CategoryType;
+import com.hyperlink.server.domain.creator.domain.CreatorRepository;
+import com.hyperlink.server.domain.dailyBriefing.infrastructure.DailyBriefingRepositoryCustom;
+import com.hyperlink.server.domain.member.domain.Career;
+import com.hyperlink.server.domain.member.domain.CareerYear;
+import com.hyperlink.server.domain.member.domain.MemberRepository;
+import com.hyperlink.server.domain.member.domain.entity.Member;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+public class DailyBriefingRepositoryCustomTest {
+
+  @Autowired
+  DailyBriefingRepositoryCustom dailyBriefingRepositoryCustom;
+  @Autowired
+  AttentionCategoryRepository attentionCategoryRepository;
+  @Autowired
+  MemberRepository memberRepository;
+  @Autowired
+  CreatorRepository creatorRepository;
+  @Autowired
+  CategoryRepository categoryRepository;
+
+  @Nested
+  @DisplayName("관심카테고리별 회원 숫자를 조회해오는 메서드는")
+  class GetMemberCountByAttentionCategoriesTest{
+
+    List<Category> categories = new ArrayList<>();
+
+    @Test
+    @DisplayName("attentionCategory 테이블에서 categoryId 조건에 맞는 행을 count 한다")
+    void getMemberCountByAttentionCategories() {
+      Member member = new Member("email", "nickname", Career.DEVELOP, CareerYear.MORE_THAN_TEN,
+          "profileImgUrl");
+      memberRepository.save(member);
+
+      for (CategoryType categoryType : CategoryType.values()) {
+        Category category = new Category(categoryType.getRequestParamName());
+        categories.add(category);
+      }
+      categoryRepository.saveAll(categories);
+
+      Category category0 = categories.get(0);
+      final long memberCount = 4L;
+      for (int i = 0; i < memberCount; i++) {
+        AttentionCategory attentionCategory = new AttentionCategory(member, category0);
+        attentionCategoryRepository.save(attentionCategory);
+      }
+
+      Category category1 = categories.get(1);
+      AttentionCategory attentionCategory = new AttentionCategory(member, category1);
+      attentionCategoryRepository.save(attentionCategory);
+
+      Category category2 = categories.get(2);
+
+      Optional<Long> memberCountByCategory0 = dailyBriefingRepositoryCustom.getMemberCountByAttentionCategories(
+          category0.getId());
+      Optional<Long> memberCountByCategory1 = dailyBriefingRepositoryCustom.getMemberCountByAttentionCategories(
+          category1.getId());
+      Optional<Long> memberCountByCategory2 = dailyBriefingRepositoryCustom.getMemberCountByAttentionCategories(
+          category2.getId());
+
+      assertThat(memberCountByCategory0).contains(memberCount);
+      assertThat(memberCountByCategory1.get()).isOne();
+      assertThat(memberCountByCategory2.get()).isZero();
+    }
+  }
+}


### PR DESCRIPTION
### 변경 내용 요약
- 데일리브리핑 API 구현 및 테스트 코드 작성

### 작업한 내용
- 1시간 단위로 스케쥴러를 돌면서 데일리브리핑을 생성해요
- 스케쥴러에서 생성된 데일리브리핑 데이터를 redis에 저장하고 controller에서는 redis에 저장된 데이터를 읽는 로직이에요!

close #129 
