### PR TITLE
[#164] 카테고리별 크리에이터 목록 조회

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -65,6 +65,10 @@ operation::MemberHistoryControllerTest/getAllHistory[snippets='http-request,http
 
 operation::CreatorControllerTest/notRecommend[snippets='http-request,http-response']
 
+=== 크리에이터 조회
+
+operation::CreatorControllerTest/retrieveCreator[snippets='http-request,http-response']
+
 == Subscription
 === 크리에이터 구독/구독 취소
 operation::SubscriptionControllerTest/subscribeOrUnsubscribeCreator[snippets='http-request,http-response']

--- a/src/main/java/com/hyperlink/server/domain/creator/application/CreatorService.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/application/CreatorService.java
@@ -87,13 +87,13 @@ public class CreatorService {
   }
 
   private void fillSubscribeStatus(Long memberId, List<CreatorAndSubscriptionCountMapper> contents,
-      List<CreatorResponse> creatorInfos, Slice<SubscribeFlagMapper> creatorRepository) {
+      List<CreatorResponse> creatorInfos, Slice<SubscribeFlagMapper> creatorSubscriptionInfo) {
     if (memberId == null) {
       contents.forEach(content -> {
-        creatorInfos.add(CreatorResponse.from(content, false));
+        creatorInfos.add(CreatorResponse.of(content, false));
       });
     } else {
-      List<SubscribeFlagMapper> isSubscribes = creatorRepository.getContent();
+      List<SubscribeFlagMapper> isSubscribes = creatorSubscriptionInfo.getContent();
       contents.forEach(content -> {
         fillSubscribeStatusIfCreatorIdMatch(creatorInfos, isSubscribes, content);
       });
@@ -105,7 +105,7 @@ public class CreatorService {
       CreatorAndSubscriptionCountMapper content) {
     for (SubscribeFlagMapper subscribeFlagMapper : isSubscribes) {
       if (subscribeFlagMapper.getCreatorId().equals(content.getCreatorId())) {
-        creatorInfos.add(CreatorResponse.from(content, subscribeFlagMapper.getIsSubscribed()));
+        creatorInfos.add(CreatorResponse.of(content, subscribeFlagMapper.getIsSubscribed()));
         break;
       }
     }

--- a/src/main/java/com/hyperlink/server/domain/creator/application/CreatorService.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/application/CreatorService.java
@@ -5,16 +5,24 @@ import com.hyperlink.server.domain.category.domain.entity.Category;
 import com.hyperlink.server.domain.category.exception.CategoryNotFoundException;
 import com.hyperlink.server.domain.creator.domain.CreatorRepository;
 import com.hyperlink.server.domain.creator.domain.entity.Creator;
+import com.hyperlink.server.domain.creator.dto.CreatorAndSubscriptionCountMapper;
 import com.hyperlink.server.domain.creator.dto.CreatorEnrollRequest;
 import com.hyperlink.server.domain.creator.dto.CreatorEnrollResponse;
+import com.hyperlink.server.domain.creator.dto.CreatorResponse;
+import com.hyperlink.server.domain.creator.dto.CreatorsRetrievalResponse;
+import com.hyperlink.server.domain.creator.dto.SubscribeFlagMapper;
 import com.hyperlink.server.domain.creator.exception.CreatorNotFoundException;
 import com.hyperlink.server.domain.member.domain.MemberRepository;
 import com.hyperlink.server.domain.member.domain.entity.Member;
 import com.hyperlink.server.domain.member.exception.MemberNotFoundException;
 import com.hyperlink.server.domain.notRecommendCreator.domain.NotRecommendCreatorRepository;
 import com.hyperlink.server.domain.notRecommendCreator.domain.entity.NotRecommendCreator;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,8 +60,54 @@ public class CreatorService {
   public void deleteCreator(Long creatorId) {
     try {
       creatorRepository.deleteById(creatorId);
-    } catch(EmptyResultDataAccessException e) {
+    } catch (EmptyResultDataAccessException e) {
       throw new CreatorNotFoundException();
+    }
+  }
+
+  public CreatorsRetrievalResponse getCreatorsByCategory(Long memberId, String categoryName,
+      Pageable pageable) {
+    Slice<CreatorAndSubscriptionCountMapper> creators;
+    List<CreatorResponse> creatorInfos = new ArrayList<>();
+    if (categoryName.equals("all")) {
+      creators = creatorRepository.findAllCreators(pageable);
+      List<CreatorAndSubscriptionCountMapper> contents = creators.getContent();
+      fillSubscribeStatus(memberId, contents, creatorInfos,
+          creatorRepository.findCreatorIdAndSubscribeFlagByMemberId(memberId, pageable));
+    } else {
+      Category category = categoryRepository.findByName(categoryName)
+          .orElseThrow(CategoryNotFoundException::new);
+      creators = creatorRepository.findAllCreatorsByCategoryId(category.getId(), pageable);
+      List<CreatorAndSubscriptionCountMapper> contents = creators.getContent();
+      fillSubscribeStatus(memberId, contents, creatorInfos,
+          creatorRepository.findCreatorIdAndSubscribeFlagByMemberIdAndCategoryId(memberId,
+              category.getId(), pageable));
+    }
+    return new CreatorsRetrievalResponse(creatorInfos, creators.hasNext());
+  }
+
+  private void fillSubscribeStatus(Long memberId, List<CreatorAndSubscriptionCountMapper> contents,
+      List<CreatorResponse> creatorInfos, Slice<SubscribeFlagMapper> creatorRepository) {
+    if (memberId == null) {
+      contents.forEach(content -> {
+        creatorInfos.add(CreatorResponse.from(content, false));
+      });
+    } else {
+      List<SubscribeFlagMapper> isSubscribes = creatorRepository.getContent();
+      contents.forEach(content -> {
+        fillSubscribeStatusIfCreatorIdMatch(creatorInfos, isSubscribes, content);
+      });
+    }
+  }
+
+  private void fillSubscribeStatusIfCreatorIdMatch(List<CreatorResponse> creatorInfos,
+      List<SubscribeFlagMapper> isSubscribes,
+      CreatorAndSubscriptionCountMapper content) {
+    for (SubscribeFlagMapper subscribeFlagMapper : isSubscribes) {
+      if (subscribeFlagMapper.getCreatorId().equals(content.getCreatorId())) {
+        creatorInfos.add(CreatorResponse.from(content, subscribeFlagMapper.getIsSubscribed()));
+        break;
+      }
     }
   }
 }

--- a/src/main/java/com/hyperlink/server/domain/creator/controller/CreatorController.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/controller/CreatorController.java
@@ -4,15 +4,20 @@ import com.hyperlink.server.domain.auth.token.exception.TokenNotExistsException;
 import com.hyperlink.server.domain.creator.application.CreatorService;
 import com.hyperlink.server.domain.creator.dto.CreatorEnrollRequest;
 import com.hyperlink.server.domain.creator.dto.CreatorEnrollResponse;
+import com.hyperlink.server.domain.creator.dto.CreatorsRetrievalResponse;
 import com.hyperlink.server.global.config.LoginMemberId;
 import java.util.Optional;
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -46,5 +51,16 @@ public class CreatorController {
       @PathVariable("creatorId") Long creatorId) {
     Long memberId = optionalMemberId.orElseThrow(TokenNotExistsException::new);
     creatorService.notRecommend(memberId, creatorId);
+  }
+
+  @GetMapping("/creators")
+  @ResponseStatus(HttpStatus.OK)
+  public CreatorsRetrievalResponse retrieveCreatorByCategory(
+      @LoginMemberId Optional<Long> optionalMemberId,
+      @RequestParam("category") @NotNull String category,
+      @RequestParam("page") @NotNull int page,
+      @RequestParam("size") @NotNull int size) {
+    Long memberId = optionalMemberId.orElse(null);
+    return creatorService.getCreatorsByCategory(memberId, category, PageRequest.of(page, size));
   }
 }

--- a/src/main/java/com/hyperlink/server/domain/creator/domain/CreatorRepository.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/domain/CreatorRepository.java
@@ -1,9 +1,43 @@
 package com.hyperlink.server.domain.creator.domain;
 
 import com.hyperlink.server.domain.creator.domain.entity.Creator;
+import com.hyperlink.server.domain.creator.dto.CreatorAndSubscriptionCountMapper;
+import com.hyperlink.server.domain.creator.dto.SubscribeFlagMapper;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CreatorRepository extends JpaRepository<Creator, Long> {
   Optional<Creator> findByName(String name);
+
+  @Query(value = "select c.id as creatorId, c.name as name, count(sub.creator.id) as subscriberAmount, c.description as description, c.profileImgUrl as profileImgUrl from Creator c "
+      + "left join Subscription sub "
+      + "on c.id = sub.creator.id "
+      + "group by c.id ")
+  Slice<CreatorAndSubscriptionCountMapper> findAllCreators(Pageable pageable);
+
+  @Query("select c.id as creatorId, c.name as name, count(sub.creator.id) as subscriberAmount, c.description as description, c.profileImgUrl as profileImgUrl from Creator c "
+      + "left join Subscription sub "
+      + "on c.id = sub.creator.id "
+      + "where c.category.id = :categoryId "
+      + "group by c.id ")
+  Slice<CreatorAndSubscriptionCountMapper> findAllCreatorsByCategoryId(@Param("categoryId") Long categoryId, Pageable pageable);
+
+  @Query(
+      "select c.id as creatorId, case when sub.member.id = :memberId then TRUE else FALSE end as isSubscribed from Creator c "
+          + "left join Subscription sub "
+          + "on c.id = sub.creator.id and sub.member.id = :memberId")
+  Slice<SubscribeFlagMapper> findCreatorIdAndSubscribeFlagByMemberId(
+      @Param("memberId") Long memberId, Pageable pageable);
+
+  @Query(
+      "select c.id as creatorId, case when sub.member.id = :memberId then TRUE else FALSE end as isSubscribed from Creator c "
+          + "left join Subscription sub "
+          + "on c.id = sub.creator.id and sub.member.id = :memberId "
+          + "where c.category.id = :categoryId")
+  Slice<SubscribeFlagMapper> findCreatorIdAndSubscribeFlagByMemberIdAndCategoryId(
+      @Param("memberId") Long memberId, @Param("categoryId") Long categoryId, Pageable pageable);
 }

--- a/src/main/java/com/hyperlink/server/domain/creator/dto/CreatorAndSubscriptionCountMapper.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/dto/CreatorAndSubscriptionCountMapper.java
@@ -1,0 +1,10 @@
+package com.hyperlink.server.domain.creator.dto;
+
+public interface CreatorAndSubscriptionCountMapper {
+
+  Long getCreatorId();
+  String getName();
+  Integer getSubscriberAmount();
+  String getDescription();
+  String getProfileImgUrl();
+}

--- a/src/main/java/com/hyperlink/server/domain/creator/dto/CreatorResponse.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/dto/CreatorResponse.java
@@ -1,7 +1,5 @@
 package com.hyperlink.server.domain.creator.dto;
 
-import com.hyperlink.server.domain.creator.domain.entity.Creator;
-
 public record CreatorResponse(
     Long creatorId,
     String creatorName,
@@ -10,7 +8,7 @@ public record CreatorResponse(
     boolean isSubscribed,
     String profileImgUrl) {
 
-  public static CreatorResponse from(CreatorAndSubscriptionCountMapper creator, boolean isSubscribed) {
+  public static CreatorResponse of(CreatorAndSubscriptionCountMapper creator, boolean isSubscribed) {
     return new CreatorResponse(creator.getCreatorId(), creator.getName(), creator.getSubscriberAmount(),
         creator.getDescription(), isSubscribed, creator.getProfileImgUrl());
   }

--- a/src/main/java/com/hyperlink/server/domain/creator/dto/CreatorResponse.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/dto/CreatorResponse.java
@@ -1,0 +1,17 @@
+package com.hyperlink.server.domain.creator.dto;
+
+import com.hyperlink.server.domain.creator.domain.entity.Creator;
+
+public record CreatorResponse(
+    Long creatorId,
+    String creatorName,
+    int subscriberAmount,
+    String creatorDescription,
+    boolean isSubscribed,
+    String profileImgUrl) {
+
+  public static CreatorResponse from(CreatorAndSubscriptionCountMapper creator, boolean isSubscribed) {
+    return new CreatorResponse(creator.getCreatorId(), creator.getName(), creator.getSubscriberAmount(),
+        creator.getDescription(), isSubscribed, creator.getProfileImgUrl());
+  }
+}

--- a/src/main/java/com/hyperlink/server/domain/creator/dto/CreatorsRetrievalResponse.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/dto/CreatorsRetrievalResponse.java
@@ -1,0 +1,9 @@
+package com.hyperlink.server.domain.creator.dto;
+
+import java.util.List;
+
+public record CreatorsRetrievalResponse(List<CreatorResponse> creators, boolean hasNext) {
+
+
+
+}

--- a/src/main/java/com/hyperlink/server/domain/creator/dto/SubscribeFlagMapper.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/dto/SubscribeFlagMapper.java
@@ -1,0 +1,6 @@
+package com.hyperlink.server.domain.creator.dto;
+
+public interface SubscribeFlagMapper {
+  Long getCreatorId();
+  Boolean getIsSubscribed();
+}

--- a/src/main/java/com/hyperlink/server/domain/subscription/domain/SubscriptionRepository.java
+++ b/src/main/java/com/hyperlink/server/domain/subscription/domain/SubscriptionRepository.java
@@ -2,7 +2,6 @@ package com.hyperlink.server.domain.subscription.domain;
 
 import com.hyperlink.server.domain.subscription.domain.entity.Subscription;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 

--- a/src/main/java/com/hyperlink/server/global/filter/AuthenticationFilter.java
+++ b/src/main/java/com/hyperlink/server/global/filter/AuthenticationFilter.java
@@ -23,7 +23,7 @@ public class AuthenticationFilter implements Filter {
   private static final String[] whitelist = {"/", "/members/logout", "/members/login",
       "/members/signup", "/profile", "/actuator/health", "/members/oauth/code/google",
       "/members/access-token", "/contents/*/view", "/daily-briefing", "/contents/all",
-      "/contents"};
+      "/contents", "/creators"};
 
 
   private final AuthTokenExtractor authTokenExtractor;

--- a/src/test/java/com/hyperlink/server/creator/application/CreatorServiceIntegrationTest.java
+++ b/src/test/java/com/hyperlink/server/creator/application/CreatorServiceIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.hyperlink.server.creator.application;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -14,6 +15,7 @@ import com.hyperlink.server.domain.creator.domain.CreatorRepository;
 import com.hyperlink.server.domain.creator.domain.entity.Creator;
 import com.hyperlink.server.domain.creator.dto.CreatorEnrollRequest;
 import com.hyperlink.server.domain.creator.dto.CreatorEnrollResponse;
+import com.hyperlink.server.domain.creator.dto.CreatorsRetrievalResponse;
 import com.hyperlink.server.domain.creator.exception.CreatorNotFoundException;
 import com.hyperlink.server.domain.member.domain.Career;
 import com.hyperlink.server.domain.member.domain.CareerYear;
@@ -22,14 +24,18 @@ import com.hyperlink.server.domain.member.domain.entity.Member;
 import com.hyperlink.server.domain.member.exception.MemberNotFoundException;
 import com.hyperlink.server.domain.notRecommendCreator.domain.NotRecommendCreatorRepository;
 import com.hyperlink.server.domain.notRecommendCreator.domain.entity.NotRecommendCreator;
+import com.hyperlink.server.domain.subscription.domain.SubscriptionRepository;
+import com.hyperlink.server.domain.subscription.domain.entity.Subscription;
 import java.util.List;
 import java.util.Optional;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
@@ -51,6 +57,9 @@ public class CreatorServiceIntegrationTest {
 
   @Autowired
   MemberRepository memberRepository;
+
+  @Autowired
+  SubscriptionRepository subscriptionRepository;
 
   @Nested
   @DisplayName("크리에이터 생성 메서드는")
@@ -164,4 +173,132 @@ public class CreatorServiceIntegrationTest {
     }
   }
 
+  @Nested
+  @DisplayName("크리에이터 조회 메서드는")
+  class CreatorRetrievalTest {
+
+    Category developCategory;
+    Category beautyCategory;
+    Creator creator1;
+    Creator creator2;
+    Creator creator3;
+    Member member1;
+    Member member2;
+    Member member3;
+
+
+    @BeforeEach
+    void setUp() {
+      developCategory = new Category("개발");
+      beautyCategory = new Category("패션");
+      categoryRepository.save(developCategory);
+      categoryRepository.save(beautyCategory);
+      creator1 = new Creator("name1", "profileImgUrl", "description", developCategory);
+      creator2 = new Creator("name2", "profileImgUrl", "description", developCategory);
+      creator3 = new Creator("name3", "profileImgUrl", "description", beautyCategory);
+
+      creatorRepository.saveAll(List.of(creator1, creator2, creator3));
+
+      member1 = new Member("email1", "nickname1", Career.DEVELOP, CareerYear.LESS_THAN_ONE,
+          "profileImgUrl");
+      member2 = new Member("email2", "nickname2", Career.DEVELOP, CareerYear.LESS_THAN_ONE,
+          "profileImgUrl");
+      member3 = new Member("email3", "nickname3", Career.DEVELOP, CareerYear.LESS_THAN_ONE,
+          "profileImgUrl");
+
+      memberRepository.saveAll(List.of(member1, member2, member3));
+
+      subscriptionRepository.save(new Subscription(member1, creator1));
+      subscriptionRepository.save(new Subscription(member2, creator1));
+      subscriptionRepository.save(new Subscription(member3, creator1));
+      subscriptionRepository.save(new Subscription(member1, creator2));
+      subscriptionRepository.save(new Subscription(member2, creator2));
+      subscriptionRepository.save(new Subscription(member3, creator3));
+    }
+
+    @Nested
+    @DisplayName("[로그인]")
+    class IsLogin {
+      @Test
+      @DisplayName("로그인 한 유저가 구독했는지, 구독자 수는 몇명인지를 고려하여 전체 카테고리의 크리에이터 정보를 조회한다.")
+      void retrieveAllCategoryCreator() {
+        int page = 0;
+        int size = 10;
+        String categoryName = "all";
+
+        CreatorsRetrievalResponse creatorsRetrievalResponse = creatorService.getCreatorsByCategory(
+            member1.getId(), categoryName, PageRequest.of(page, size));
+
+        assertThat(creatorsRetrievalResponse.creators()).hasSize(3);
+        assertThat(creatorsRetrievalResponse.creators().get(0).isSubscribed()).isTrue();
+        assertThat(creatorsRetrievalResponse.creators().get(0).subscriberAmount()).isEqualTo(3);
+      }
+
+      @Test
+      @DisplayName("로그인 한 유저가 구독했는지, 구독자 수는 몇명인지를 고려하여 전체 카테고리의 크리에이터 정보를 조회한다.")
+      void retrieveByCategoryCreator() {
+        int page = 0;
+        int size = 10;
+        String categoryName = developCategory.getName();
+
+        CreatorsRetrievalResponse creatorsRetrievalResponse = creatorService.getCreatorsByCategory(
+            member1.getId(), categoryName, PageRequest.of(page, size));
+
+        assertThat(creatorsRetrievalResponse.creators()).hasSize(2);
+        assertThat(creatorsRetrievalResponse.creators().get(0).isSubscribed()).isTrue();
+        assertThat(creatorsRetrievalResponse.creators().get(0).subscriberAmount()).isEqualTo(3);
+      }
+    }
+
+    @Nested
+    @DisplayName("[비 로그인]")
+    class IsNotLogin {
+      @Test
+      @DisplayName("구독 여부는 false로, 구독자 수는 몇명인지 고려하여 전체 카테고리의 크리에이터 정보를 조회한다.")
+      void retrieveAllCategoryCreatorNotLogin() {
+        int page = 0;
+        int size = 10;
+        String categoryName = "all";
+
+        CreatorsRetrievalResponse creatorsRetrievalResponse = creatorService.getCreatorsByCategory(
+            null, categoryName, PageRequest.of(page, size));
+
+        assertThat(creatorsRetrievalResponse.creators()).hasSize(3);
+        assertThat(creatorsRetrievalResponse.creators().get(0).isSubscribed()).isFalse();
+        assertThat(creatorsRetrievalResponse.creators().get(0).subscriberAmount()).isEqualTo(3);
+      }
+
+      @Test
+      @DisplayName("구독 여부는 false로, 구독자 수는 몇명인지 고려하여 전체 카테고리의 크리에이터 정보를 조회한다.")
+      void retrieveByCategoryCreatorNotLogin() {
+        int page = 0;
+        int size = 10;
+        String categoryName = developCategory.getName();
+
+        CreatorsRetrievalResponse creatorsRetrievalResponse = creatorService.getCreatorsByCategory(
+            null, categoryName, PageRequest.of(page, size));
+
+        assertThat(creatorsRetrievalResponse.creators()).hasSize(2);
+        assertThat(creatorsRetrievalResponse.creators().get(0).isSubscribed()).isFalse();
+        assertThat(creatorsRetrievalResponse.creators().get(0).subscriberAmount()).isEqualTo(3);
+      }
+    }
+
+    @Nested
+    @DisplayName("[실패]")
+    class Fail {
+
+      @Test
+      @DisplayName("카테고리 입력이 잘못되면 CategoryNotFoundException 이 발생한다.")
+      void invalidCategoryNameThrowsCategoryNotFoundException() {
+        int page = 0;
+        int size = 10;
+        String invalidCategoryName = "invalid";
+
+        assertThrows(CategoryNotFoundException.class,
+            () -> creatorService.getCreatorsByCategory(null, invalidCategoryName,
+                PageRequest.of(page, size)));
+      }
+    }
+  }
 }

--- a/src/test/java/com/hyperlink/server/creator/controller/CreatorControllerTest.java
+++ b/src/test/java/com/hyperlink/server/creator/controller/CreatorControllerTest.java
@@ -314,7 +314,7 @@ public class CreatorControllerTest extends AuthSetupForMock {
         String category = "develop";
         CreatorResponse naverD2 = new CreatorResponse(1L, "네이버 D2", 500000, "네이버 D2 블로그입니다.", true,
             "https://img.naverd2.com/logo");
-        CreatorResponse kakao = new CreatorResponse(1L, "카카오 디벨로퍼스", 230421, "카카오 디벨로퍼스 블로그입니다.", false,
+        CreatorResponse kakao = new CreatorResponse(2L, "카카오 디벨로퍼스", 230421, "카카오 디벨로퍼스 블로그입니다.", false,
             "https://img.kakao.com/logo");
         CreatorsRetrievalResponse creatorsRetrievalResponse = new CreatorsRetrievalResponse(
             List.of(naverD2, kakao), false);

--- a/src/test/java/com/hyperlink/server/creator/domain/CreatorRepositoryTest.java
+++ b/src/test/java/com/hyperlink/server/creator/domain/CreatorRepositoryTest.java
@@ -1,12 +1,25 @@
 package com.hyperlink.server.creator.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hyperlink.server.domain.category.domain.CategoryRepository;
 import com.hyperlink.server.domain.category.domain.entity.Category;
 import com.hyperlink.server.domain.creator.domain.CreatorRepository;
 import com.hyperlink.server.domain.creator.domain.entity.Creator;
+import com.hyperlink.server.domain.creator.dto.CreatorAndSubscriptionCountMapper;
+import com.hyperlink.server.domain.member.domain.Career;
+import com.hyperlink.server.domain.member.domain.CareerYear;
+import com.hyperlink.server.domain.member.domain.MemberRepository;
+import com.hyperlink.server.domain.member.domain.entity.Member;
+import com.hyperlink.server.domain.subscription.domain.SubscriptionRepository;
+import com.hyperlink.server.domain.subscription.domain.entity.Subscription;
+import com.hyperlink.server.domain.creator.dto.SubscribeFlagMapper;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -15,6 +28,8 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = Replace.NONE)
@@ -25,6 +40,12 @@ public class CreatorRepositoryTest {
 
   @Autowired
   CreatorRepository creatorRepository;
+
+  @Autowired
+  MemberRepository memberRepository;
+
+  @Autowired
+  SubscriptionRepository subscriptionRepository;
 
   @Test
   @DisplayName("컨텐트를 이름으로 검색할 수 있다.")
@@ -60,5 +81,109 @@ public class CreatorRepositoryTest {
 
       assertThat(creatorRepository.existsById(creator.getId())).isFalse();
     }
+  }
+
+  @Nested
+  @DisplayName("크리에이터 조회 시")
+  class CreatorRetrieval {
+
+    Category developCategory;
+    Category beautyCategory;
+    Creator creator1;
+    Creator creator2;
+    Creator creator3;
+    Member member1;
+    Member member2;
+    Member member3;
+
+
+    @BeforeEach
+    void setUp() {
+      developCategory = new Category("개발");
+      beautyCategory = new Category("패션");
+      categoryRepository.save(developCategory);
+      categoryRepository.save(beautyCategory);
+      creator1 = new Creator("name1", "profileImgUrl", "description", developCategory);
+      creator2 = new Creator("name2", "profileImgUrl", "description", developCategory);
+      creator3 = new Creator("name3", "profileImgUrl", "description", beautyCategory);
+
+      creatorRepository.saveAll(List.of(creator1, creator2, creator3));
+
+      member1 = new Member("email1", "nickname1", Career.DEVELOP, CareerYear.LESS_THAN_ONE,
+          "profileImgUrl");
+      member2 = new Member("email2", "nickname2", Career.DEVELOP, CareerYear.LESS_THAN_ONE,
+          "profileImgUrl");
+      member3 = new Member("email3", "nickname3", Career.DEVELOP, CareerYear.LESS_THAN_ONE,
+          "profileImgUrl");
+
+      memberRepository.saveAll(List.of(member1, member2, member3));
+
+      subscriptionRepository.save(new Subscription(member1, creator1));
+      subscriptionRepository.save(new Subscription(member2, creator1));
+      subscriptionRepository.save(new Subscription(member3, creator1));
+      subscriptionRepository.save(new Subscription(member1, creator2));
+      subscriptionRepository.save(new Subscription(member2, creator2));
+      subscriptionRepository.save(new Subscription(member3, creator3));
+    }
+
+
+    @Test
+    @DisplayName("전체 카테고리에 대해 크리에이터 정보와 구독자 수를 조회할 수 있다.")
+    void retrieveCreatorsForAllCategory() {
+      Slice<CreatorAndSubscriptionCountMapper> creatorsSlice = creatorRepository.findAllCreators(
+          PageRequest.of(0, 10));
+
+      assertEquals(false, creatorsSlice.hasNext());
+      assertThat(creatorsSlice.getContent()).hasSize(3);
+      assertThat(creatorsSlice.getContent().get(0).getSubscriberAmount()).isEqualTo(3);
+      assertThat(creatorsSlice.getContent().get(1).getSubscriberAmount()).isEqualTo(2);
+      assertThat(creatorsSlice.getContent().get(2).getSubscriberAmount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("특정 카테고리에 대해 크리에이터 정보와 구독자 수를 조회할 수 있다.")
+    void retrieveCreatorsByCategory() {
+      Slice<CreatorAndSubscriptionCountMapper> creatorsSlice = creatorRepository.findAllCreatorsByCategoryId(
+          developCategory.getId(), PageRequest.of(0, 10));
+
+      assertEquals(false, creatorsSlice.hasNext());
+      assertThat(creatorsSlice.getContent()).hasSize(2);
+      assertThat(creatorsSlice.getContent().get(0).getSubscriberAmount()).isEqualTo(3);
+      assertThat(creatorsSlice.getContent().get(1).getSubscriberAmount()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("모든 카테고리의 크리에이터에 대해 내가 구독했는지 여부를 조회할 수 있다.")
+    void retrieveIsSubscribedForAllCategory() {
+      Slice<SubscribeFlagMapper> flags = creatorRepository.findCreatorIdAndSubscribeFlagByMemberId(
+          member1.getId(), PageRequest.of(0, 10));
+
+      assertEquals(false, flags.hasNext());
+      assertThat(flags.getContent()).hasSize(3);
+      assertThat(flags.getContent().get(0).getIsSubscribed()).isEqualTo(true);
+      assertThat(flags.getContent().get(1).getIsSubscribed()).isEqualTo(true);
+      assertThat(flags.getContent().get(2).getIsSubscribed()).isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("특정 카테고리의 크리에이터에 대해 내가 구독했는지 여부를 조회할 수 있다.")
+    void retrieveIsSubscribedByCategory() {
+      Slice<SubscribeFlagMapper> flags = creatorRepository.findCreatorIdAndSubscribeFlagByMemberIdAndCategoryId(
+          member1.getId(), developCategory.getId(), PageRequest.of(0, 10));
+
+      assertEquals(false, flags.hasNext());
+      assertThat(flags.getContent()).hasSize(2);
+      assertThat(flags.getContent().get(0).getIsSubscribed()).isEqualTo(true);
+      assertThat(flags.getContent().get(1).getIsSubscribed()).isEqualTo(true);
+
+      Slice<SubscribeFlagMapper> flags2 = creatorRepository.findCreatorIdAndSubscribeFlagByMemberIdAndCategoryId(
+          member1.getId(), beautyCategory.getId(), PageRequest.of(0, 10));
+
+      assertEquals(false, flags2.hasNext());
+      assertThat(flags2.getContent()).hasSize(1);
+      assertThat(flags2.getContent().get(0).getIsSubscribed()).isEqualTo(false);
+    }
+
+
   }
 }


### PR DESCRIPTION
### 변경 내용 요약
- 구독 정보, 구독자 수를 고려한 크리에이터 정보 조회 기능 구현
- Creator 레포지토리, 서비스 통합 테스트, 컨트롤러 슬라이스 테스트 구현
- 크리에이터 조회 api docs 추가

### 작업한 내용
- 로그인, 비로그인 상태를 고려한 구독 상태 조회, 카테고리 별 크리에이터 조회 기능을 구현했습니다.
- 비로그인 상태에서도 조회가능해야 하므로 whitelist에 /creators 를 추가했습니다.


close #164