### PR TITLE
[#190]: attentionCategory 변경시 이전 관심목록이 남아있던 문제 해결

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -45,10 +45,6 @@ operation::members/login[snippets='http-request,http-response,response-fields']
 
 operation::members/mypage[snippets='http-request,http-response,response-fields']
 
-=== 관심목록 변경
-
-operation::members/attention-category[snippets='http-request,http-response,response-fields']
-
 === 프로필 변경
 
 operation::members/update[snippets='http-request,http-response,response-fields']
@@ -66,17 +62,23 @@ operation::MemberHistoryControllerTest/getAllHistory[snippets='http-request,http
 operation::CreatorControllerTest/notRecommend[snippets='http-request,http-response']
 
 == Subscription
+
 === 크리에이터 구독/구독 취소
+
 operation::SubscriptionControllerTest/subscribeOrUnsubscribeCreator[snippets='http-request,http-response']
 
 === 구독 피드 카테고리별 조회
+
 operation::SubscriptionControllerTest/retrieveByCategory[snippets='http-request,http-response']
 
 === 구독 피드 전체 카테고리 조회
+
 operation::SubscriptionControllerTest/retrieveAllCategory[snippets='http-request,http-response']
 
 == Daily-Briefing
+
 === 데일리 브리핑 조회
+
 operation::DailyBriefingControllerTest/getDailyBriefing[snippets='http-request,http-response']
 
 == Admin
@@ -90,5 +92,11 @@ operation::CreatorControllerTest/deleteCreator[snippets='http-request,http-respo
 operation::CreatorControllerTest/enrollCreator[snippets='http-request,http-response']
 
 === 컨텐츠 활성화
+
 operation::ContentControllerTest/activateContent[snippets='http-request,http-response']
 
+== AttentionCategory
+
+=== 관심카테고리 변경
+
+operation::Attention-category/update[snippets='http-request,http-response,response-fields']

--- a/src/main/java/com/hyperlink/server/domain/attentionCategory/application/AttentionCategoryService.java
+++ b/src/main/java/com/hyperlink/server/domain/attentionCategory/application/AttentionCategoryService.java
@@ -6,7 +6,9 @@ import com.hyperlink.server.domain.attentionCategory.dto.AttentionCategoryRespon
 import com.hyperlink.server.domain.category.domain.CategoryRepository;
 import com.hyperlink.server.domain.category.domain.entity.Category;
 import com.hyperlink.server.domain.category.exception.CategoryNotFoundException;
+import com.hyperlink.server.domain.member.domain.MemberRepository;
 import com.hyperlink.server.domain.member.domain.entity.Member;
+import com.hyperlink.server.domain.member.exception.MemberNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -17,25 +19,33 @@ import org.springframework.transaction.annotation.Transactional;
 public class AttentionCategoryService {
 
   private final AttentionCategoryRepository attentionCategoryRepository;
+  private final MemberRepository memberRepository;
   private final CategoryRepository categoryRepository;
 
   public AttentionCategoryService(AttentionCategoryRepository attentionCategoryRepository,
-      CategoryRepository categoryRepository) {
+      MemberRepository memberRepository, CategoryRepository categoryRepository) {
     this.attentionCategoryRepository = attentionCategoryRepository;
+    this.memberRepository = memberRepository;
     this.categoryRepository = categoryRepository;
   }
 
   @Transactional
-  public AttentionCategoryResponse changeAttentionCategory(Member member,
-      List<String> attentionCategorys) {
+  public AttentionCategoryResponse changeAttentionCategory(Long memberId,
+      List<String> attentionCategories) {
 
+    Member foundMember = memberRepository.findById(memberId)
+        .orElseThrow(MemberNotFoundException::new);
+
+    attentionCategoryRepository.deleteAttentionCategoriesByMember(foundMember);
+    
     List<String> savedAttentionCategory = new ArrayList<>();
-    attentionCategorys.stream().forEach(categoryName -> {
+    attentionCategories.stream().forEach(categoryName -> {
       Category category = categoryRepository.findByName(categoryName)
           .orElseThrow(CategoryNotFoundException::new);
-      attentionCategoryRepository.save(new AttentionCategory(member, category));
+      attentionCategoryRepository.save(new AttentionCategory(foundMember, category));
       savedAttentionCategory.add(category.getName());
     });
     return AttentionCategoryResponse.from(savedAttentionCategory);
   }
 }
+

--- a/src/main/java/com/hyperlink/server/domain/attentionCategory/controller/AttentionCategoryController.java
+++ b/src/main/java/com/hyperlink/server/domain/attentionCategory/controller/AttentionCategoryController.java
@@ -1,0 +1,33 @@
+package com.hyperlink.server.domain.attentionCategory.controller;
+
+import com.hyperlink.server.domain.attentionCategory.application.AttentionCategoryService;
+import com.hyperlink.server.domain.attentionCategory.dto.AttentionCategoryRequest;
+import com.hyperlink.server.domain.attentionCategory.dto.AttentionCategoryResponse;
+import com.hyperlink.server.domain.member.exception.MemberNotFoundException;
+import com.hyperlink.server.global.config.LoginMemberId;
+import java.util.Optional;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class AttentionCategoryController {
+
+  private final AttentionCategoryService attentionCategoryService;
+
+  public AttentionCategoryController(AttentionCategoryService attentionCategoryService) {
+    this.attentionCategoryService = attentionCategoryService;
+  }
+
+  @PutMapping("/attention-category/update")
+  @ResponseStatus(HttpStatus.OK)
+  public AttentionCategoryResponse changeAttentionCategory(
+      @LoginMemberId Optional<Long> optionalId,
+      @RequestBody AttentionCategoryRequest attentionCategoryRequest) {
+    Long memberId = optionalId.orElseThrow(MemberNotFoundException::new);
+    return attentionCategoryService.changeAttentionCategory(memberId,
+        attentionCategoryRequest.attentionCategory());
+  }
+}

--- a/src/main/java/com/hyperlink/server/domain/attentionCategory/domain/AttentionCategoryRepository.java
+++ b/src/main/java/com/hyperlink/server/domain/attentionCategory/domain/AttentionCategoryRepository.java
@@ -1,6 +1,7 @@
 package com.hyperlink.server.domain.attentionCategory.domain;
 
 import com.hyperlink.server.domain.attentionCategory.domain.entity.AttentionCategory;
+import com.hyperlink.server.domain.member.domain.entity.Member;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -9,4 +10,6 @@ public interface AttentionCategoryRepository extends JpaRepository<AttentionCate
 
   @Query("select at.category.id from AttentionCategory at where at.member.id = :memberId")
   List<Long> findAttentionCategoryIdsByMemberId(Long memberId);
+
+  void deleteAttentionCategoriesByMember(Member member);
 }

--- a/src/main/java/com/hyperlink/server/domain/member/application/MemberService.java
+++ b/src/main/java/com/hyperlink/server/domain/member/application/MemberService.java
@@ -1,9 +1,6 @@
 package com.hyperlink.server.domain.member.application;
 
 import com.hyperlink.server.domain.attentionCategory.application.AttentionCategoryService;
-import com.hyperlink.server.domain.attentionCategory.domain.AttentionCategoryRepository;
-import com.hyperlink.server.domain.attentionCategory.dto.AttentionCategoryRequest;
-import com.hyperlink.server.domain.attentionCategory.dto.AttentionCategoryResponse;
 import com.hyperlink.server.domain.auth.token.JwtTokenProvider;
 import com.hyperlink.server.domain.auth.token.RefreshToken;
 import com.hyperlink.server.domain.auth.token.RefreshTokenRepository;
@@ -29,18 +26,14 @@ public class MemberService {
   private final AttentionCategoryService attentionCategoryService;
   private final JwtTokenProvider jwtTokenProvider;
   private final RefreshTokenRepository refreshTokenRepository;
-  private final AttentionCategoryRepository attentionCategoryRepository;
 
   public MemberService(MemberRepository memberRepository,
       AttentionCategoryService attentionCategoryService,
-      JwtTokenProvider jwtTokenProvider, RefreshTokenRepository refreshTokenRepository,
-      AttentionCategoryRepository attentionCategoryRepository) {
+      JwtTokenProvider jwtTokenProvider, RefreshTokenRepository refreshTokenRepository) {
     this.memberRepository = memberRepository;
-
     this.attentionCategoryService = attentionCategoryService;
     this.jwtTokenProvider = jwtTokenProvider;
     this.refreshTokenRepository = refreshTokenRepository;
-    this.attentionCategoryRepository = attentionCategoryRepository;
   }
 
   public boolean existsMemberByEmail(String email) {
@@ -50,7 +43,7 @@ public class MemberService {
   @Transactional
   public SignUpResult signUp(SignUpRequest signUpRequest, String profileUrl) {
     Member savedMember = memberRepository.save(SignUpRequest.to(signUpRequest, profileUrl));
-    attentionCategoryService.changeAttentionCategory(savedMember,
+    attentionCategoryService.changeAttentionCategory(savedMember.getId(),
         signUpRequest.attentionCategory());
 
     Long memberId = savedMember.getId();
@@ -65,17 +58,6 @@ public class MemberService {
     Member foundMember = memberRepository.findById(memberId)
         .orElseThrow(MemberNotFoundException::new);
     return MyPageResponse.from(foundMember);
-  }
-
-  @Transactional
-  public AttentionCategoryResponse changeAttentionCategory(
-      Long memberId, AttentionCategoryRequest attentionCategoryRequest) {
-    Member foundMember = memberRepository.findById(memberId)
-        .orElseThrow(MemberNotFoundException::new);
-    AttentionCategoryResponse attentionCategoryResponse = attentionCategoryService.changeAttentionCategory(
-        foundMember, attentionCategoryRequest.attentionCategory());
-
-    return attentionCategoryResponse;
   }
 
   @Transactional

--- a/src/main/java/com/hyperlink/server/domain/member/controller/MemberController.java
+++ b/src/main/java/com/hyperlink/server/domain/member/controller/MemberController.java
@@ -1,7 +1,5 @@
 package com.hyperlink.server.domain.member.controller;
 
-import com.hyperlink.server.domain.attentionCategory.dto.AttentionCategoryRequest;
-import com.hyperlink.server.domain.attentionCategory.dto.AttentionCategoryResponse;
 import com.hyperlink.server.domain.auth.application.AuthService;
 import com.hyperlink.server.domain.auth.oauth.GoogleAccessToken;
 import com.hyperlink.server.domain.auth.token.AuthTokenExtractor;
@@ -77,15 +75,6 @@ public class MemberController {
     log.info("#### optional: " + optionalId.isEmpty());
     Long memberId = optionalId.orElseThrow(MemberNotFoundException::new);
     return memberService.myInfo(memberId);
-  }
-
-  @PutMapping("/members/attention-category")
-  @ResponseStatus(HttpStatus.OK)
-  public AttentionCategoryResponse changeAttentionCategory(
-      @LoginMemberId Optional<Long> optionalId,
-      @RequestBody AttentionCategoryRequest attentionCategoryRequest) {
-    Long memberId = optionalId.orElseThrow(MemberNotFoundException::new);
-    return memberService.changeAttentionCategory(memberId, attentionCategoryRequest);
   }
 
   private GoogleAccessToken getGoogleAccessToken(HttpServletRequest request) {

--- a/src/test/java/com/hyperlink/server/attentionCategory/application/AttentionCategoryServiceIntegrationTest.java
+++ b/src/test/java/com/hyperlink/server/attentionCategory/application/AttentionCategoryServiceIntegrationTest.java
@@ -43,7 +43,7 @@ class AttentionCategoryServiceIntegrationTest {
         new Member("rldnd5555@gmail.com", "chocho", Career.DEVELOP, CareerYear.MORE_THAN_TEN, "url",
             1990, "man"));
 
-    attentionCategoryService.changeAttentionCategory(savedMember, attentionCategorys);
+    attentionCategoryService.changeAttentionCategory(savedMember.getId(), attentionCategorys);
     List<AttentionCategory> allAttentionCategory = attentionCategoryRepository.findAll();
 
     List<Category> result = allAttentionCategory.stream()
@@ -59,15 +59,12 @@ class AttentionCategoryServiceIntegrationTest {
   @DisplayName("관심목록 추가시 해당하는 Category가 없다면 CategoryNotFoundException 을 던진다.")
   @Test
   void setAttentionCategoryInCorrectTest() {
-
-//    Category develop = categoryRepository.save(new Category("develop"));
-    Category beauty = categoryRepository.save(new Category("beauty"));
     List<String> attentionCategorys = Arrays.asList("food", "beauty");
     Member savedMember = memberRepository.save(
         new Member("rldnd5555@gmail.com", "chocho", Career.DEVELOP, CareerYear.MORE_THAN_TEN, "url",
             1990, "man"));
     Assertions.assertThatThrownBy(() ->
-        attentionCategoryService.changeAttentionCategory(savedMember, attentionCategorys)
+        attentionCategoryService.changeAttentionCategory(savedMember.getId(), attentionCategorys)
     ).isInstanceOf(
         CategoryNotFoundException.class);
   }

--- a/src/test/java/com/hyperlink/server/attentionCategory/controller/AttentionCategoryControllerTest.java
+++ b/src/test/java/com/hyperlink/server/attentionCategory/controller/AttentionCategoryControllerTest.java
@@ -1,0 +1,78 @@
+package com.hyperlink.server.attentionCategory.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hyperlink.server.AuthSetupForMock;
+import com.hyperlink.server.domain.attentionCategory.application.AttentionCategoryService;
+import com.hyperlink.server.domain.attentionCategory.controller.AttentionCategoryController;
+import com.hyperlink.server.domain.attentionCategory.dto.AttentionCategoryRequest;
+import com.hyperlink.server.domain.attentionCategory.dto.AttentionCategoryResponse;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@AutoConfigureRestDocs
+@MockBean(JpaMetamodelMappingContext.class)
+@WebMvcTest(controllers = AttentionCategoryController.class)
+class AttentionCategoryControllerTest extends AuthSetupForMock {
+
+  @MockBean
+  private AttentionCategoryService attentionCategoryService;
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @Test
+  void changeAttentionCategoryTest() throws Exception {
+    authSetup();
+
+    List<String> nameList = Arrays.asList("develop", "beauty");
+    AttentionCategoryRequest attentionCategoryRequest = new AttentionCategoryRequest(nameList);
+    AttentionCategoryResponse attentionCategoryResponse = new AttentionCategoryResponse(nameList);
+    given(attentionCategoryService.changeAttentionCategory(memberId,
+        attentionCategoryRequest.attentionCategory()))
+        .willReturn(attentionCategoryResponse);
+
+    mockMvc.perform(MockMvcRequestBuilders
+            .put("/attention-category/update")
+            .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(attentionCategoryRequest)))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andDo(print())
+        .andDo(document("Attention-category/update",
+            preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint()),
+            requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("AccessToken")),
+            responseFields(
+                fieldWithPath("attentionCategory").type(JsonFieldType.ARRAY)
+                    .description("관심 카테고리 목록"))));
+  }
+
+}

--- a/src/test/java/com/hyperlink/server/member/application/MemberServiceIntegrationTest.java
+++ b/src/test/java/com/hyperlink/server/member/application/MemberServiceIntegrationTest.java
@@ -3,8 +3,6 @@ package com.hyperlink.server.member.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.hyperlink.server.domain.attentionCategory.dto.AttentionCategoryRequest;
-import com.hyperlink.server.domain.attentionCategory.dto.AttentionCategoryResponse;
 import com.hyperlink.server.domain.auth.token.AuthTokenExtractor;
 import com.hyperlink.server.domain.auth.token.RefreshTokenRepository;
 import com.hyperlink.server.domain.category.domain.CategoryRepository;
@@ -20,7 +18,6 @@ import com.hyperlink.server.domain.member.dto.MyPageResponse;
 import com.hyperlink.server.domain.member.dto.SignUpRequest;
 import com.hyperlink.server.domain.member.dto.SignUpResult;
 import com.hyperlink.server.domain.member.exception.MemberNotFoundException;
-import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -94,38 +91,6 @@ class MemberServiceIntegrationTest {
   @Test
   void myPageInCorrectTest() {
     assertThatThrownBy(() -> memberService.myInfo(1001L)).isInstanceOf(
-        MemberNotFoundException.class);
-  }
-
-
-  @DisplayName("관심 목록 카테고리를 변경할 수 있다.")
-  @Test
-  void changeAttentionCategoryCorrectTest() {
-
-    Category develop = categoryRepository.save(new Category("develop"));
-    Category beauty = categoryRepository.save(new Category("beauty"));
-
-    Member saveMember = memberRepository.save(
-        new Member("rldnd1234@naver.com", "Chocho", Career.DEVELOP, CareerYear.MORE_THAN_TEN,
-            "localhost", 1995, "man"));
-
-    List<String> nameList = Arrays.asList("develop", "beauty");
-    AttentionCategoryRequest attentionCategoryRequest = new AttentionCategoryRequest(nameList);
-    AttentionCategoryResponse attentionCategoryResponse = memberService.changeAttentionCategory(
-        saveMember.getId(), attentionCategoryRequest);
-    List<String> resultNameList = attentionCategoryResponse.attentionCategory();
-    assertThat(resultNameList).contains(nameList.get(0));
-    assertThat(resultNameList).contains(nameList.get(1));
-  }
-
-  @DisplayName("관심 목록 카테고리를 변경할 경우 잘못된 MemberId가 들어온다면 MemberNotFoundException을 던진다.")
-  @Test
-  void changeAttentionCategoryInCorrectTest() {
-    List<String> nameList = Arrays.asList("develop", "beauty");
-    AttentionCategoryRequest attentionCategoryRequest = new AttentionCategoryRequest(nameList);
-
-    assertThatThrownBy(
-        () -> memberService.changeAttentionCategory(1000L, attentionCategoryRequest)).isInstanceOf(
         MemberNotFoundException.class);
   }
 

--- a/src/test/java/com/hyperlink/server/member/controller/MemberControllerMockTest.java
+++ b/src/test/java/com/hyperlink/server/member/controller/MemberControllerMockTest.java
@@ -17,8 +17,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hyperlink.server.AuthSetupForMock;
-import com.hyperlink.server.domain.attentionCategory.dto.AttentionCategoryRequest;
-import com.hyperlink.server.domain.attentionCategory.dto.AttentionCategoryResponse;
 import com.hyperlink.server.domain.auth.application.AuthService;
 import com.hyperlink.server.domain.auth.oauth.GoogleAccessTokenRepository;
 import com.hyperlink.server.domain.auth.token.RefreshTokenCookieProvider;
@@ -30,8 +28,6 @@ import com.hyperlink.server.domain.member.dto.MyPageResponse;
 import com.hyperlink.server.domain.member.dto.ProfileImgResponse;
 import com.hyperlink.server.domain.member.s3.AwsS3Service;
 import com.hyperlink.server.global.config.LoginMemberIdArgumentResolver;
-import java.util.Arrays;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
@@ -90,33 +86,6 @@ public class MemberControllerMockTest extends AuthSetupForMock {
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andDo(print());
-  }
-
-  @Test
-  void changeAttentionCategoryTest() throws Exception {
-    authSetup();
-
-    List<String> nameList = Arrays.asList("develop", "beauty");
-    AttentionCategoryRequest attentionCategoryRequest = new AttentionCategoryRequest(nameList);
-    AttentionCategoryResponse attentionCategoryResponse = new AttentionCategoryResponse(nameList);
-    given(memberService.changeAttentionCategory(memberId, attentionCategoryRequest))
-        .willReturn(attentionCategoryResponse);
-
-    mockMvc.perform(MockMvcRequestBuilders
-            .put("/members/attention-category")
-            .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(attentionCategoryRequest)))
-        .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andDo(print())
-        .andDo(document("members/attention-category",
-            preprocessRequest(prettyPrint()),
-            preprocessResponse(prettyPrint()),
-            requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("AccessToken")),
-            responseFields(
-                fieldWithPath("attentionCategory").type(JsonFieldType.ARRAY)
-                    .description("관심 카테고리 목록"))));
   }
 
   @Test


### PR DESCRIPTION
### 변경 내용 요약
<!-- 한두줄로 간단히 요약해 주세요. -->
- attentionCategory 변경시 이전 관심목록이 남아있던 문제 해결

### 작업한 내용
<!-- 본문 내용에는 PR을 처음 보는 사람도 이해하기 쉽도록 변경 사항 등을 하이픈(-)으로 구분하여 적어주세요.
문장 형식으로 적더라도 하이픈으로 구분해주세요 -->
- attentionCategory 변경시 이전 관심목록이 남아있던 문제 해결
- attentionCategory를 members에서 분리

### 기타사항
<!-- 기타 공유하고싶은 점을 적어주세요 -->

close #190 
