### PR TITLE
[#183] [어드민 페이지] 크리에이터 전체 조회 기능 구현

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -81,6 +81,9 @@ operation::DailyBriefingControllerTest/getDailyBriefing[snippets='http-request,h
 
 == Admin
 
+=== 크리에이터 조회
+operation::CreatorControllerTest/retrieveCreatorsAdmin['http-request,http-response']
+
 === 크리에이터 삭제
 
 operation::CreatorControllerTest/deleteCreator[snippets='http-request,http-response']

--- a/src/main/java/com/hyperlink/server/domain/creator/application/CreatorService.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/application/CreatorService.java
@@ -5,6 +5,8 @@ import com.hyperlink.server.domain.category.domain.entity.Category;
 import com.hyperlink.server.domain.category.exception.CategoryNotFoundException;
 import com.hyperlink.server.domain.creator.domain.CreatorRepository;
 import com.hyperlink.server.domain.creator.domain.entity.Creator;
+import com.hyperlink.server.domain.creator.dto.CreatorAdminResponse;
+import com.hyperlink.server.domain.creator.dto.CreatorAdminResponses;
 import com.hyperlink.server.domain.creator.dto.CreatorEnrollRequest;
 import com.hyperlink.server.domain.creator.dto.CreatorEnrollResponse;
 import com.hyperlink.server.domain.creator.exception.CreatorNotFoundException;
@@ -13,8 +15,12 @@ import com.hyperlink.server.domain.member.domain.entity.Member;
 import com.hyperlink.server.domain.member.exception.MemberNotFoundException;
 import com.hyperlink.server.domain.notRecommendCreator.domain.NotRecommendCreatorRepository;
 import com.hyperlink.server.domain.notRecommendCreator.domain.entity.NotRecommendCreator;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -55,5 +61,14 @@ public class CreatorService {
     } catch(EmptyResultDataAccessException e) {
       throw new CreatorNotFoundException();
     }
+  }
+
+  public CreatorAdminResponses retrieveCreatorsForAdmin(PageRequest pageable) {
+    Slice<Creator> creatorSlice = creatorRepository.findCreators(pageable);
+    List<Creator> creators = creatorSlice.getContent();
+
+    List<CreatorAdminResponse> creatorAdminResponses = creators.stream()
+        .map(CreatorAdminResponse::from).toList();
+    return new CreatorAdminResponses(creatorAdminResponses, creatorSlice.hasNext());
   }
 }

--- a/src/main/java/com/hyperlink/server/domain/creator/controller/CreatorController.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/controller/CreatorController.java
@@ -2,25 +2,45 @@ package com.hyperlink.server.domain.creator.controller;
 
 import com.hyperlink.server.domain.auth.token.exception.TokenNotExistsException;
 import com.hyperlink.server.domain.creator.application.CreatorService;
+import com.hyperlink.server.domain.creator.dto.CreatorAdminResponse;
+import com.hyperlink.server.domain.creator.dto.CreatorAdminResponses;
 import com.hyperlink.server.domain.creator.dto.CreatorEnrollRequest;
 import com.hyperlink.server.domain.creator.dto.CreatorEnrollResponse;
+import com.hyperlink.server.domain.member.exception.MemberNotFoundException;
 import com.hyperlink.server.global.config.LoginMemberId;
 import java.util.Optional;
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+@Validated
 @RestController
 @RequiredArgsConstructor
 public class CreatorController {
 
   private final CreatorService creatorService;
+
+  @GetMapping("/admin/creators")
+  @ResponseStatus(HttpStatus.OK)
+  public CreatorAdminResponses retrieveAdminCreators(
+      @LoginMemberId Optional<Long> optionalMemberId,
+      @RequestParam("page") @NotNull int page,
+      @RequestParam("size") @NotNull int size
+  ) {
+//    optionalMemberId.orElseThrow(MemberNotFoundException::new);
+    return creatorService.retrieveCreatorsForAdmin(PageRequest.of(page, size));
+  }
 
 
   @PostMapping("/admin/creators")

--- a/src/main/java/com/hyperlink/server/domain/creator/domain/CreatorRepository.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/domain/CreatorRepository.java
@@ -1,9 +1,16 @@
 package com.hyperlink.server.domain.creator.domain;
 
 import com.hyperlink.server.domain.creator.domain.entity.Creator;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CreatorRepository extends JpaRepository<Creator, Long> {
   Optional<Creator> findByName(String name);
+
+  @Query("select c from Creator c join fetch c.category")
+  Slice<Creator> findCreators(Pageable pageable);
 }

--- a/src/main/java/com/hyperlink/server/domain/creator/dto/CreatorAdminResponse.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/dto/CreatorAdminResponse.java
@@ -1,0 +1,10 @@
+package com.hyperlink.server.domain.creator.dto;
+
+import com.hyperlink.server.domain.creator.domain.entity.Creator;
+
+public record CreatorAdminResponse(Long creatorId, String name, String description, String categoryName) {
+  public static CreatorAdminResponse from(Creator creator) {
+    return new CreatorAdminResponse(creator.getId(), creator.getName(), creator.getDescription(),
+        creator.getCategoryName());
+  }
+}

--- a/src/main/java/com/hyperlink/server/domain/creator/dto/CreatorAdminResponses.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/dto/CreatorAdminResponses.java
@@ -1,0 +1,7 @@
+package com.hyperlink.server.domain.creator.dto;
+
+import java.util.List;
+
+public record CreatorAdminResponses(List<CreatorAdminResponse> creators, boolean hasNext) {
+
+}

--- a/src/test/java/com/hyperlink/server/creator/application/CreatorServiceIntegrationTest.java
+++ b/src/test/java/com/hyperlink/server/creator/application/CreatorServiceIntegrationTest.java
@@ -2,6 +2,7 @@ package com.hyperlink.server.creator.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -12,6 +13,7 @@ import com.hyperlink.server.domain.category.exception.CategoryNotFoundException;
 import com.hyperlink.server.domain.creator.application.CreatorService;
 import com.hyperlink.server.domain.creator.domain.CreatorRepository;
 import com.hyperlink.server.domain.creator.domain.entity.Creator;
+import com.hyperlink.server.domain.creator.dto.CreatorAdminResponses;
 import com.hyperlink.server.domain.creator.dto.CreatorEnrollRequest;
 import com.hyperlink.server.domain.creator.dto.CreatorEnrollResponse;
 import com.hyperlink.server.domain.creator.exception.CreatorNotFoundException;
@@ -30,6 +32,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
@@ -164,4 +167,29 @@ public class CreatorServiceIntegrationTest {
     }
   }
 
+
+  @Nested
+  @DisplayName("[Admin] 크리에이터 전체 조회 메소드는")
+  class CreatorAdminRetrieval {
+    @Test
+    @DisplayName("성공하면 전체 크리에이터를 조회한.")
+    public void success() throws Exception {
+      Category develop = new Category("개발");
+      Category beauty = new Category("패션");
+      categoryRepository.save(develop);
+      categoryRepository.save(beauty);
+      Creator creator1 = new Creator("개발크리에이터1", "profileImgUrl1", "description", develop);
+      Creator creator2 = new Creator("개발크리에이터2", "profileImgUrl2", "description", develop);
+      Creator creator3 = new Creator("개발크리에이터3", "profileImgUrl3", "description", develop);
+      Creator creator4 = new Creator("뷰티크리에이터1", "profileImgUrl4", "description", beauty);
+      Creator creator5 = new Creator("뷰티크리에이터2", "profileImgUrl5", "description", beauty);
+      creatorRepository.saveAll(List.of(creator1, creator2, creator3, creator4, creator5));
+
+      CreatorAdminResponses creatorAdminResponses = creatorService.retrieveCreatorsForAdmin(
+          PageRequest.of(0, 10));
+
+      assertEquals(5, creatorAdminResponses.creators().size());
+      assertEquals("패션", creatorAdminResponses.creators().get(4).categoryName());
+    }
+  }
 }

--- a/src/test/java/com/hyperlink/server/creator/controller/CreatorControllerTest.java
+++ b/src/test/java/com/hyperlink/server/creator/controller/CreatorControllerTest.java
@@ -5,8 +5,10 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
@@ -15,6 +17,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -25,6 +28,8 @@ import com.hyperlink.server.domain.category.domain.entity.Category;
 import com.hyperlink.server.domain.creator.application.CreatorService;
 import com.hyperlink.server.domain.creator.controller.CreatorController;
 import com.hyperlink.server.domain.creator.domain.entity.Creator;
+import com.hyperlink.server.domain.creator.dto.CreatorAdminResponse;
+import com.hyperlink.server.domain.creator.dto.CreatorAdminResponses;
 import com.hyperlink.server.domain.creator.dto.CreatorEnrollRequest;
 import com.hyperlink.server.domain.creator.dto.CreatorEnrollResponse;
 import com.hyperlink.server.domain.creator.exception.CreatorNotFoundException;
@@ -32,6 +37,7 @@ import com.hyperlink.server.domain.member.domain.Career;
 import com.hyperlink.server.domain.member.domain.CareerYear;
 import com.hyperlink.server.domain.member.domain.entity.Member;
 import com.hyperlink.server.domain.notRecommendCreator.domain.entity.NotRecommendCreator;
+import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -283,6 +289,67 @@ public class CreatorControllerTest extends AuthSetupForMock {
             .andExpect(response -> Assertions.assertTrue(
                 response.getResolvedException() instanceof CreatorNotFoundException))
             .andDo(print());
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("[Admin] 크리에이터 전체 조회 API는")
+  class CreatorRetrievalAdminTest {
+
+    @Nested
+    @DisplayName("[성공]")
+    class Success {
+
+      @BeforeEach
+      void setUp() {
+        authSetup();
+      }
+
+      @Test
+      @DisplayName("전체 크리에이터 정보를 조회한다.")
+      void retrieveCreatorForAdminReturnsOK() throws Exception {
+        String page = "0";
+        String size = "10";
+        CreatorAdminResponse creatorAdminResponse1 = new CreatorAdminResponse(1L, "네이버 D2",
+            "네이버 D2 블로그", "develop");
+        CreatorAdminResponse creatorAdminResponse2 = new CreatorAdminResponse(2L, "카카오 디벨로퍼스",
+            "카카오 디벨로퍼스 블로그", "develop");
+        CreatorAdminResponse creatorAdminResponse3 = new CreatorAdminResponse(3L, "토스 테크",
+            "토스 테크 블로그", "develop");
+        CreatorAdminResponse creatorAdminResponse4 = new CreatorAdminResponse(4L, "VOGUE",
+            "VOGUE 패션 메거진", "beauty");
+        CreatorAdminResponses creatorAdminResponses = new CreatorAdminResponses(
+            List.of(creatorAdminResponse1, creatorAdminResponse2, creatorAdminResponse3,
+                creatorAdminResponse4), false);
+
+        when(creatorService.retrieveCreatorsForAdmin(any())).thenReturn(creatorAdminResponses);
+
+        mockMvc.perform(get("/admin/creators")
+                .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                .param("page", page)
+                .param("size", size))
+            .andExpect(status().isOk())
+            .andDo(print())
+            .andDo(document("CreatorControllerTest/retrieveCreatorsAdmin",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestHeaders(
+                    headerWithName("Authorization").description("accessToken")
+                ),
+                responseFields(
+                    fieldWithPath("creators[]").type(JsonFieldType.ARRAY).description("크리에이터 목록"),
+                    fieldWithPath("creators[].creatorId").type(JsonFieldType.NUMBER)
+                        .description("크리에이터 id"),
+                    fieldWithPath("creators[].name").type(JsonFieldType.STRING)
+                        .description("크리에이터 이름"),
+                    fieldWithPath("creators[].description").type(JsonFieldType.STRING)
+                        .description("크리에이터 소개글"),
+                    fieldWithPath("creators[].categoryName").type(JsonFieldType.STRING)
+                        .description("크리에이터 카테고리 이름"),
+                    fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 존재 여부")
+                )
+            ));
       }
     }
   }


### PR DESCRIPTION
### 변경 내용 요약
- Admin 페이지에서 크리에이터 관리를 위한 크리에이터 전체 조회 기능을 구현했습니다.

### 작업한 내용
- 크리에이터 정보 가져올 때 카테고리 정보도 가져올 수 있도록 fetch join 사용해 N + 1 문제 해결


close #183
