### PR TITLE
[#184] [어드민 페이지] 비활성화된 컨텐츠 전체 조회 기능 구현

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -101,6 +101,10 @@ operation::CreatorControllerTest/deleteCreator[snippets='http-request,http-respo
 
 operation::CreatorControllerTest/enrollCreator[snippets='http-request,http-response']
 
+=== 비활성 컨텐츠 조회
+
+operation::ContentControllerTest/retrieveInactiveContents[snippets='http-request,http-response']
+
 === 컨텐츠 활성화
 
 operation::ContentControllerTest/activateContent[snippets='http-request,http-response']

--- a/src/main/java/com/hyperlink/server/domain/content/application/ContentService.java
+++ b/src/main/java/com/hyperlink/server/domain/content/application/ContentService.java
@@ -7,6 +7,8 @@ import com.hyperlink.server.domain.category.exception.CategoryNotFoundException;
 import com.hyperlink.server.domain.common.ContentDtoFactoryService;
 import com.hyperlink.server.domain.content.domain.ContentRepository;
 import com.hyperlink.server.domain.content.domain.entity.Content;
+import com.hyperlink.server.domain.content.dto.ContentAdminResponse;
+import com.hyperlink.server.domain.content.dto.ContentAdminResponses;
 import com.hyperlink.server.domain.content.dto.ContentEnrollResponse;
 import com.hyperlink.server.domain.content.dto.GetContentsCommonResponse;
 import com.hyperlink.server.domain.content.dto.SearchResponse;
@@ -21,8 +23,11 @@ import com.hyperlink.server.domain.memberHistory.application.MemberHistoryServic
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -147,5 +152,14 @@ public class ContentService {
     Content content = contentRepository.findById(contentId)
         .orElseThrow(ContentNotFoundException::new);
     content.makeViewable(true);
+  }
+
+  public ContentAdminResponses retrieveInactivatedContents(Pageable pageable) {
+    Page<Content> inactivatedContentsPage = contentRepository.findInactivatedContents(pageable);
+    List<Content> inactivatedContents = inactivatedContentsPage.getContent();
+    List<ContentAdminResponse> inactivatedContentAdminResponses = inactivatedContents.stream()
+        .map(ContentAdminResponse::from).toList();
+    return ContentAdminResponses.of(inactivatedContentAdminResponses, inactivatedContentsPage.getNumber(),
+        inactivatedContentsPage.getTotalPages());
   }
 }

--- a/src/main/java/com/hyperlink/server/domain/content/controller/ContentController.java
+++ b/src/main/java/com/hyperlink/server/domain/content/controller/ContentController.java
@@ -2,6 +2,7 @@ package com.hyperlink.server.domain.content.controller;
 
 import com.hyperlink.server.domain.auth.token.exception.TokenNotExistsException;
 import com.hyperlink.server.domain.content.application.ContentService;
+import com.hyperlink.server.domain.content.dto.ContentAdminResponses;
 import com.hyperlink.server.domain.content.dto.GetContentsCommonResponse;
 import com.hyperlink.server.domain.content.dto.PatchInquiryResponse;
 import com.hyperlink.server.domain.content.dto.SearchResponse;
@@ -82,6 +83,16 @@ public class ContentController {
     Long memberId = optionalMemberId.orElse(null);
     return contentService.retrieveTrendAllCategoriesContents(
         memberId, sort, PageRequest.of(page, size));
+  }
+
+  @GetMapping("/admin/contents")
+  @ResponseStatus(HttpStatus.OK)
+  public ContentAdminResponses retrieveInactivatedContentsForAdmin(@LoginMemberId Optional<Long> optionalMemberId,
+      @RequestParam("page") @NotNull @Min(0) int page,
+      @RequestParam("size") @NotNull @Min(1) int size
+  ) {
+//    optionalMemberId.orElseThrow(MemberNotFoundException::new);
+    return contentService.retrieveInactivatedContents(PageRequest.of(page, size));
   }
 
   @PostMapping("/admin/contents/{contentId}/activate")

--- a/src/main/java/com/hyperlink/server/domain/content/controller/ContentController.java
+++ b/src/main/java/com/hyperlink/server/domain/content/controller/ContentController.java
@@ -91,7 +91,7 @@ public class ContentController {
       @RequestParam("page") @NotNull @Min(0) int page,
       @RequestParam("size") @NotNull @Min(1) int size
   ) {
-//    optionalMemberId.orElseThrow(MemberNotFoundException::new);
+    optionalMemberId.orElseThrow(MemberNotFoundException::new);
     return contentService.retrieveInactivatedContents(PageRequest.of(page, size));
   }
 

--- a/src/main/java/com/hyperlink/server/domain/content/domain/ContentRepository.java
+++ b/src/main/java/com/hyperlink/server/domain/content/domain/ContentRepository.java
@@ -22,6 +22,6 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
 
   Integer countByCreatedAtAfter(LocalDateTime date);
 
-  @Query("select c from Content c where c.isViewable = false")
+  @Query("select c from Content c where c.isViewable = false order by c.id desc")
   Page<Content> findInactivatedContents(Pageable pageable);
 }

--- a/src/main/java/com/hyperlink/server/domain/content/domain/ContentRepository.java
+++ b/src/main/java/com/hyperlink/server/domain/content/domain/ContentRepository.java
@@ -3,6 +3,8 @@ package com.hyperlink.server.domain.content.domain;
 import com.hyperlink.server.domain.content.domain.entity.Content;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -19,4 +21,7 @@ public interface ContentRepository extends JpaRepository<Content, Long> {
   boolean existsByLink(String link);
 
   Integer countByCreatedAtAfter(LocalDateTime date);
+
+  @Query("select c from Content c where c.isViewable = false")
+  Page<Content> findInactivatedContents(Pageable pageable);
 }

--- a/src/main/java/com/hyperlink/server/domain/content/dto/ContentAdminResponse.java
+++ b/src/main/java/com/hyperlink/server/domain/content/dto/ContentAdminResponse.java
@@ -1,0 +1,9 @@
+package com.hyperlink.server.domain.content.dto;
+
+import com.hyperlink.server.domain.content.domain.entity.Content;
+
+public record ContentAdminResponse(Long contentId, String title, String link) {
+  public static ContentAdminResponse from(Content content) {
+    return new ContentAdminResponse(content.getId(), content.getTitle(), content.getLink());
+  }
+}

--- a/src/main/java/com/hyperlink/server/domain/content/dto/ContentAdminResponses.java
+++ b/src/main/java/com/hyperlink/server/domain/content/dto/ContentAdminResponses.java
@@ -1,0 +1,11 @@
+package com.hyperlink.server.domain.content.dto;
+
+import java.util.List;
+
+public record ContentAdminResponses(List<ContentAdminResponse> contents, int currentPage,
+                                    int totalPage) {
+  public static ContentAdminResponses of(List<ContentAdminResponse> contents, int currentPage,
+      int totalPage) {
+    return new ContentAdminResponses(contents, currentPage, totalPage);
+  }
+}

--- a/src/main/java/com/hyperlink/server/domain/content/infrastructure/ContentRepositoryCustom.java
+++ b/src/main/java/com/hyperlink/server/domain/content/infrastructure/ContentRepositoryCustom.java
@@ -188,8 +188,8 @@ public class ContentRepositoryCustom {
         .add(content.likeCount.multiply(LIKE_COUNT_WEIGHT)).desc();
   }
 
-  private OrderSpecifier<LocalDateTime> recentOrderType() {
-    return content.createdAt.desc();
+  private OrderSpecifier<Long> recentOrderType() {
+    return content.id.desc();
   }
 
   private BooleanExpression eqCreatorId(Long creatorId) {

--- a/src/test/java/com/hyperlink/server/content/application/ContentServiceIntegrationTest.java
+++ b/src/test/java/com/hyperlink/server/content/application/ContentServiceIntegrationTest.java
@@ -446,7 +446,7 @@ public class ContentServiceIntegrationTest {
 
           List<ContentResponse> contents = getContentsCommonResponse.contents();
           assertThat(contents).hasSize(3);
-          assertThat(contents.get(0).createdAt()).isLessThanOrEqualTo(
+          assertThat(contents.get(0).createdAt()).isGreaterThanOrEqualTo(
               contents.get(contents.size() - 1).createdAt());
         }
 
@@ -496,7 +496,7 @@ public class ContentServiceIntegrationTest {
 
             List<ContentResponse> contents = getContentsCommonResponse.contents();
             assertThat(contents).hasSize(4);
-            assertThat(contents.get(0).createdAt()).isLessThanOrEqualTo(
+            assertThat(contents.get(0).createdAt()).isGreaterThanOrEqualTo(
                 contents.get(contents.size() - 1).createdAt());
           }
 
@@ -531,7 +531,7 @@ public class ContentServiceIntegrationTest {
 
             List<ContentResponse> contents = getContentsCommonResponse.contents();
             assertThat(contents).hasSize(3);
-            assertThat(contents.get(0).createdAt()).isLessThanOrEqualTo(
+            assertThat(contents.get(0).createdAt()).isGreaterThanOrEqualTo(
                 contents.get(contents.size() - 1).createdAt());
           }
 
@@ -570,7 +570,7 @@ public class ContentServiceIntegrationTest {
 
         List<ContentResponse> contents = getContentsCommonResponse.contents();
         assertThat(contents).hasSize(3);
-        assertThat(contents.get(0).createdAt()).isLessThanOrEqualTo(
+        assertThat(contents.get(0).createdAt()).isGreaterThanOrEqualTo(
             contents.get(contents.size() - 1).createdAt());
       }
 

--- a/src/test/java/com/hyperlink/server/content/application/ContentServiceIntegrationTest.java
+++ b/src/test/java/com/hyperlink/server/content/application/ContentServiceIntegrationTest.java
@@ -16,6 +16,7 @@ import com.hyperlink.server.domain.category.exception.CategoryNotFoundException;
 import com.hyperlink.server.domain.content.application.ContentService;
 import com.hyperlink.server.domain.content.domain.ContentRepository;
 import com.hyperlink.server.domain.content.domain.entity.Content;
+import com.hyperlink.server.domain.content.dto.ContentAdminResponses;
 import com.hyperlink.server.domain.content.dto.ContentEnrollResponse;
 import com.hyperlink.server.domain.content.dto.ContentResponse;
 import com.hyperlink.server.domain.content.dto.GetContentsCommonResponse;
@@ -52,8 +53,10 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -410,7 +413,7 @@ public class ContentServiceIntegrationTest {
     Member member;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws InterruptedException {
       Creator creator2 = new Creator("코딩팩토리", "profileUrl", "description", category);
       creatorRepository.save(creator2);
       Category category2 = new Category("패션");
@@ -593,6 +596,28 @@ public class ContentServiceIntegrationTest {
         List<ContentResponse> contents = getContentsCommonResponse.contents();
         assertThat(contents).hasSize(3);
         assertThat(contents.get(0).title()).isEqualTo("제목3");
+      }
+    }
+
+    @Nested
+    @DisplayName("[어드민 페이지] 비활성화된 글을")
+    class InactivatedContent {
+
+      @Nested
+      @DisplayName("[성공]")
+      class Success {
+        @Test
+        @DisplayName("최신순으로 조회할 수 있다.")
+        void retrieveInactivatedContent() {
+          contentService.activateContent(content2.getId());
+
+          ContentAdminResponses contentAdminResponses = contentService.retrieveInactivatedContents(
+              PageRequest.of(0, 10));
+
+          assertThat(contentAdminResponses.contents()).hasSize(3);
+          assertThat(contentAdminResponses.contents().get(0).title()).isEqualTo("제목4");
+          assertThat(contentAdminResponses.contents().get(2).title()).isEqualTo("제목1");
+        }
       }
     }
   }


### PR DESCRIPTION
### 변경 내용 요약
- 컨텐츠 생성일을 기준으로 DESC로 조회했을 때 제대로 조회하지 못하는 문제가 발생했고 원인을 파악하지 못했습니다.
  - 추측하기론 DB에 저장된 타임 포맷이 초 단위로만 되어 있어서 초 단위로만 시간 역순 정렬하는 것으로 보입니다.
  - 실제로 데이터도 최신순으로 잘 가는 것을 확인하였지만 id의 역순으로 정렬하면 더 정확하게 할 수 있을 것 같아서 id 기준으로 변경했습니다.
- 해당 이슈의 본 기능인 어드민 페이지에서 아직 발행되지 않은 비화성화된 컨텐츠를 최신순으로 정렬하여 조회하는 기능을 구현했습니다. 

### 작업한 내용
- 비활성화된 컨텐츠 전체보기 기능 구현
- 비활성화된 컨텐츠 전체보기 테스트 코드 작성
- 데이터는 id의 역순으로 조회(시간 역순과 동일)


close #184
