### PR TITLE
[#185] [어드민 페이지] 컨텐츠 삭제 기능 구현

### DIFF
--- a/src/main/java/com/hyperlink/server/domain/content/application/ContentService.java
+++ b/src/main/java/com/hyperlink/server/domain/content/application/ContentService.java
@@ -179,4 +179,13 @@ public class ContentService {
     foundContent.subtractLike();
 
   }
+
+  @Transactional
+  public void deleteContentsById(Long contentId) {
+    boolean exists = contentRepository.existsById(contentId);
+    if (!exists) {
+      throw new ContentNotFoundException();
+    }
+    contentRepository.deleteById(contentId);
+  }
 }

--- a/src/main/java/com/hyperlink/server/domain/content/controller/ContentController.java
+++ b/src/main/java/com/hyperlink/server/domain/content/controller/ContentController.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -93,6 +94,16 @@ public class ContentController {
   ) {
     optionalMemberId.orElseThrow(MemberNotFoundException::new);
     return contentService.retrieveInactivatedContents(PageRequest.of(page, size));
+  }
+
+  @DeleteMapping("/admin/contents/{contentId}")
+  @ResponseStatus(HttpStatus.OK)
+  public void deleteContentsForAdmin(
+      @LoginMemberId Optional<Long> optionalMemberId,
+      @PathVariable("contentId") Long contentId
+  ) {
+    optionalMemberId.orElseThrow(MemberNotFoundException::new);
+    contentService.deleteContentsById(contentId);
   }
 
   @PostMapping("/admin/contents/{contentId}/activate")

--- a/src/test/java/com/hyperlink/server/content/application/ContentServiceIntegrationTest.java
+++ b/src/test/java/com/hyperlink/server/content/application/ContentServiceIntegrationTest.java
@@ -674,4 +674,42 @@ public class ContentServiceIntegrationTest {
       categoryRepository.deleteById(category2.getId());
     }
   }
+
+  @Nested
+  @DisplayName("[어드민 페이지] 컨텐츠 삭제 메서드는")
+  class DeleteContentsByAdmin {
+
+    Content content;
+    @BeforeEach
+    void setUp() {
+      content = new Content("제목1", "contentImgUrl", "link1", creator, category);
+      contentRepository.save(content);
+    }
+
+    @Nested
+    @DisplayName("[성공]")
+    class Success {
+
+      @Test
+      @DisplayName("컨텐츠가 존재하면 해당 컨텐츠를 삭제한다.")
+      void deleteContentsById() {
+        contentService.deleteContentsById(content.getId());
+
+        assertThat(contentRepository.findById(content.getId()).isEmpty());
+      }
+    }
+
+    @Nested
+    @DisplayName("[실패]")
+    class Fail {
+      @Test
+      @DisplayName("컨텐츠가 존재하면 해당 컨텐츠를 삭제한다.")
+      void deleteContentsById() {
+        Long invalidContentId = -1L;
+
+        assertThrows(ContentNotFoundException.class,
+            () -> contentService.deleteContentsById(invalidContentId));
+      }
+    }
+  }
 }

--- a/src/test/java/com/hyperlink/server/content/controller/ContentControllerTest.java
+++ b/src/test/java/com/hyperlink/server/content/controller/ContentControllerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -636,6 +637,45 @@ public class ContentControllerTest extends AuthSetupForMock {
                             .description("컨텐츠 연결 외부 링크"),
                         fieldWithPath("currentPage").type(JsonFieldType.NUMBER).description("현재 페이지 번호"),
                         fieldWithPath("totalPage").type(JsonFieldType.NUMBER).description("전체 페이지 번호")
+                    )
+                )
+            );
+      }
+    }
+
+  }
+
+  @Nested
+  @DisplayName("[Admin] 컨텐츠 삭제 API는")
+  class DeleteContentByAdmin {
+    @BeforeEach
+    void setUp() {
+      authSetup();
+    }
+
+    @Nested
+    @DisplayName("[성공]")
+    class Success {
+      @Test
+      @DisplayName("컨텐츠를 삭제한다.")
+      void deleteContentById() throws Exception {
+        Long contentId = 1L;
+
+        doNothing().when(contentService).deleteContentsById(contentId);
+
+        mockMvc.perform(
+                delete("/admin/contents/" + contentId)
+                    .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+                    .characterEncoding("UTF-8")
+            ).andExpect(status().isOk())
+            .andDo(print())
+            .andDo(
+                document(
+                    "ContentControllerTest/deleteContentByAdmin",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    requestHeaders(
+                        headerWithName(HttpHeaders.AUTHORIZATION).description("AccessToken")
                     )
                 )
             );


### PR DESCRIPTION
### 변경 내용 요약
- 어드민 페이지에서 컨텐츠를 삭제할 수 있는 API를 구현합니다.

### 작업한 내용
- 어드민이 컨텐츠를 삭제하기 기능을 구현
- 컨텐츠를 삭제하기 테스트 코드 작성

close #185