### PR TITLE
[#210] 카테고리 별 하루의 조회수 증가분 계산하기 구현

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -115,6 +115,10 @@ operation::ContentControllerTest/retrieveInactiveContents[snippets='http-request
 
 operation::ContentControllerTest/activateContent[snippets='http-request,http-response']
 
+=== 최근 7일 카테고리별 조회수 조회
+
+operation::AdminController/countViewCountByCategory[snippets='http-request,http-response']
+
 == AttentionCategory
 
 === 관심카테고리 변경

--- a/src/main/java/com/hyperlink/server/domain/admin/application/AdminService.java
+++ b/src/main/java/com/hyperlink/server/domain/admin/application/AdminService.java
@@ -1,0 +1,64 @@
+package com.hyperlink.server.domain.admin.application;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hyperlink.server.domain.admin.domain.vo.CategoryAndView;
+import com.hyperlink.server.domain.admin.dto.CategoryViewResponse;
+import com.hyperlink.server.domain.admin.dto.CategoryViewResponses;
+import com.hyperlink.server.domain.admin.dto.CountingViewByCategoryDto;
+import com.hyperlink.server.domain.category.domain.CategoryRepository;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AdminService {
+
+  private final CategoryRepository categoryRepository;
+  private final RedisTemplate<String, String> categoryViewRedisTemplate;
+  private static final int VIEW_COUNT_AGGREGATION_START_FROM = 7;
+  private static final String STANDARD_TIME_PATTERN = "yyyy-MM-dd";
+  private static final String CATEGORY_VIEW = "category-view";
+
+  public CategoryViewResponses countViewCountByCategory() {
+    LocalDate now = LocalDate.now();
+    List<CategoryViewResponse> weeklyViewCounts = new LinkedList<>();
+    for (int nDay = VIEW_COUNT_AGGREGATION_START_FROM; nDay > 0; nDay--) {
+      String targetDate = now.minusDays(nDay).toString();
+      List<CountingViewByCategoryDto> viewCountsByCategories = categoryRepository.countViewsByCategoryAndDate(
+          targetDate);
+      CategoryViewResponse viewCountsForOneDay = CategoryViewResponse.of(
+          viewCountsByCategories.stream()
+              .map(viewCountsByCategory -> new CategoryAndView(
+                  viewCountsByCategory.getCategoryName(), viewCountsByCategory.getViewCount()))
+              .collect(Collectors.toList()), targetDate);
+      weeklyViewCounts.add(viewCountsForOneDay);
+    }
+    return new CategoryViewResponses(weeklyViewCounts, now.toString());
+  }
+
+  public Optional<CategoryViewResponses> getCategoryView() {
+    String standardTime = LocalDate.now().format(DateTimeFormatter.ofPattern(STANDARD_TIME_PATTERN));
+    String categoryView = categoryViewRedisTemplate.opsForValue().get(CATEGORY_VIEW);
+    if (categoryView == null) {
+      return Optional.empty();
+    }
+    try {
+      ObjectMapper objectMapper = new ObjectMapper();
+      return Optional.of(objectMapper.readValue(categoryView, CategoryViewResponses.class));
+    } catch (Exception e) {
+      log.error(e.getMessage());
+      return Optional.empty();
+    }
+  }
+}

--- a/src/main/java/com/hyperlink/server/domain/admin/application/AdminService.java
+++ b/src/main/java/com/hyperlink/server/domain/admin/application/AdminService.java
@@ -25,7 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminService {
 
   private final CategoryRepository categoryRepository;
-  private final RedisTemplate<String, String> categoryViewRedisTemplate;
+  private final RedisTemplate<String, Object> redisTemplate;
   private static final int VIEW_COUNT_AGGREGATION_START_FROM = 7;
   private static final String STANDARD_TIME_PATTERN = "yyyy-MM-dd";
   private static final String CATEGORY_VIEW = "category-view";
@@ -49,7 +49,7 @@ public class AdminService {
 
   public Optional<CategoryViewResponses> getCategoryView() {
     String standardTime = LocalDate.now().format(DateTimeFormatter.ofPattern(STANDARD_TIME_PATTERN));
-    String categoryView = categoryViewRedisTemplate.opsForValue().get(CATEGORY_VIEW);
+    String categoryView = (String) redisTemplate.opsForValue().get(CATEGORY_VIEW);
     if (categoryView == null) {
       return Optional.empty();
     }

--- a/src/main/java/com/hyperlink/server/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/hyperlink/server/domain/admin/controller/AdminController.java
@@ -1,0 +1,26 @@
+package com.hyperlink.server.domain.admin.controller;
+
+import com.hyperlink.server.domain.admin.application.AdminService;
+import com.hyperlink.server.domain.admin.dto.CategoryViewResponses;
+import com.hyperlink.server.global.config.LoginMemberId;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AdminController {
+
+  private final AdminService adminService;
+
+  @GetMapping("/admin/dashboard/all-category/view")
+  @ResponseStatus(HttpStatus.OK)
+  public CategoryViewResponses getDailyBriefingForAdmin(@LoginMemberId Optional<Long> optionalMemberId) {
+    return adminService.getCategoryView().orElseGet(adminService::countViewCountByCategory);
+  }
+
+
+}

--- a/src/main/java/com/hyperlink/server/domain/admin/controller/AdminScheduler.java
+++ b/src/main/java/com/hyperlink/server/domain/admin/controller/AdminScheduler.java
@@ -17,17 +17,16 @@ public class AdminScheduler {
 
   private final ObjectMapper objectMapper;
   private final AdminService adminService;
-  private final RedisTemplate<String, String> categoryViewRedisTemplate;
+  private final RedisTemplate<String, Object> redisTemplate;
   private static final String CATEGORY_VIEW = "category-view";
 
-  @Scheduled(cron = "0 5 0 * * *", zone = "Asia/Seoul")
+  @Scheduled(cron = "0 25 20 * * *", zone = "Asia/Seoul")
   void createCategoryViewDashboardData() {
     log.info("[Admin] 카테고리 별 조회수 수집");
     CategoryViewResponses categoryViewResponses = adminService.countViewCountByCategory();
-
     try {
       String categoryViewResponsesJson = objectMapper.writeValueAsString(categoryViewResponses);
-      categoryViewRedisTemplate.opsForValue().set(CATEGORY_VIEW, categoryViewResponsesJson);
+      redisTemplate.opsForValue().set(CATEGORY_VIEW, categoryViewResponsesJson);
     } catch (JsonProcessingException e) {
       log.error("[Admin] 카테고리 별 조회수 수집 실패", e);
     }

--- a/src/main/java/com/hyperlink/server/domain/admin/controller/AdminScheduler.java
+++ b/src/main/java/com/hyperlink/server/domain/admin/controller/AdminScheduler.java
@@ -1,0 +1,37 @@
+package com.hyperlink.server.domain.admin.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hyperlink.server.domain.admin.application.AdminService;
+import com.hyperlink.server.domain.admin.dto.CategoryViewResponses;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class AdminScheduler {
+
+  private final ObjectMapper objectMapper;
+  private final AdminService adminService;
+  private final RedisTemplate<String, String> categoryViewRedisTemplate;
+  private static final String CATEGORY_VIEW = "category-view";
+
+  @Scheduled(cron = "0 5 0 * * *", zone = "Asia/Seoul")
+  void createCategoryViewDashboardData() {
+    log.info("[Admin] 카테고리 별 조회수 수집");
+    CategoryViewResponses categoryViewResponses = adminService.countViewCountByCategory();
+
+    try {
+      String categoryViewResponsesJson = objectMapper.writeValueAsString(categoryViewResponses);
+      categoryViewRedisTemplate.opsForValue().set(CATEGORY_VIEW, categoryViewResponsesJson);
+    } catch (JsonProcessingException e) {
+      log.error("[Admin] 카테고리 별 조회수 수집 실패", e);
+    }
+    log.info("[Admin] 카테고리 별 조회수 수집 완료");
+  }
+
+}

--- a/src/main/java/com/hyperlink/server/domain/admin/domain/vo/CategoryAndView.java
+++ b/src/main/java/com/hyperlink/server/domain/admin/domain/vo/CategoryAndView.java
@@ -1,0 +1,19 @@
+package com.hyperlink.server.domain.admin.domain.vo;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class CategoryAndView {
+  private final String categoryName;
+  private final int viewCount;
+
+  @JsonCreator
+  public CategoryAndView(
+      @JsonProperty("categoryName") String categoryName,
+      @JsonProperty("viewCount") int viewCount) {
+    this.categoryName = categoryName;
+    this.viewCount = viewCount;
+  }
+}

--- a/src/main/java/com/hyperlink/server/domain/admin/dto/CategoryViewResponse.java
+++ b/src/main/java/com/hyperlink/server/domain/admin/dto/CategoryViewResponse.java
@@ -1,0 +1,11 @@
+package com.hyperlink.server.domain.admin.dto;
+
+import com.hyperlink.server.domain.admin.domain.vo.CategoryAndView;
+import java.util.List;
+
+public record CategoryViewResponse(List<CategoryAndView> results, String date) {
+
+  public static CategoryViewResponse of(List<CategoryAndView> results, String date) {
+    return new CategoryViewResponse(results, date);
+  }
+}

--- a/src/main/java/com/hyperlink/server/domain/admin/dto/CategoryViewResponses.java
+++ b/src/main/java/com/hyperlink/server/domain/admin/dto/CategoryViewResponses.java
@@ -1,0 +1,7 @@
+package com.hyperlink.server.domain.admin.dto;
+
+import java.util.List;
+
+public record CategoryViewResponses(List<CategoryViewResponse> weeklyViewCounts, String createdDate) {
+
+}

--- a/src/main/java/com/hyperlink/server/domain/admin/dto/CountingViewByCategoryDto.java
+++ b/src/main/java/com/hyperlink/server/domain/admin/dto/CountingViewByCategoryDto.java
@@ -1,0 +1,7 @@
+package com.hyperlink.server.domain.admin.dto;
+
+public interface CountingViewByCategoryDto {
+  Long getCategoryId();
+  String getCategoryName();
+  int getViewCount();
+}

--- a/src/main/java/com/hyperlink/server/domain/admin/exception/CategoryViewNotFoundException.java
+++ b/src/main/java/com/hyperlink/server/domain/admin/exception/CategoryViewNotFoundException.java
@@ -1,0 +1,14 @@
+package com.hyperlink.server.domain.admin.exception;
+
+import com.hyperlink.server.global.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class CategoryViewNotFoundException extends BusinessException {
+
+  private static final String MESSAGE = "카테고리별 조회수 조회 결과를 찾을 수 없습니다.";
+  private static final HttpStatus status = HttpStatus.NOT_FOUND;
+
+  public CategoryViewNotFoundException() {
+    super(MESSAGE, status);
+  }
+}

--- a/src/main/java/com/hyperlink/server/domain/category/domain/CategoryRepository.java
+++ b/src/main/java/com/hyperlink/server/domain/category/domain/CategoryRepository.java
@@ -1,6 +1,8 @@
 package com.hyperlink.server.domain.category.domain;
 
+import com.hyperlink.server.domain.admin.dto.CountingViewByCategoryDto;
 import com.hyperlink.server.domain.category.domain.entity.Category;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,4 +16,15 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
   @Override
   List<Category> findAll();
+
+  @Query(value =
+      "select category.category_id as categoryId, category.name as categoryName, count(viewed_category.category_id) as viewCount from category "
+          + "left join (select c.category_id, mh.created_at from member_history mh "
+          + "inner join content c "
+          + "on mh.content_id = c.content_id "
+          + "where DATE(mh.created_at) = :date) as viewed_category "
+          + "on category.category_id = viewed_category.category_id "
+          + "group by category.category_id "
+          + "order by category.category_id", nativeQuery = true)
+  List<CountingViewByCategoryDto> countViewsByCategoryAndDate(String date);
 }

--- a/src/main/java/com/hyperlink/server/domain/dailyBriefing/DailyBriefingScheduler.java
+++ b/src/main/java/com/hyperlink/server/domain/dailyBriefing/DailyBriefingScheduler.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 public class DailyBriefingScheduler {
 
   private final DailyBriefingService dailyBriefingService;
-  private final RedisTemplate<String, GetDailyBriefingResponse> dailyBriefingResponseRedisTemplate;
+  private final RedisTemplate<String, Object> redisTemplate;
 
   @Scheduled(cron = "0 0 0-23 * * *", zone = "Asia/Seoul")
   void createDailyBriefing() {
@@ -23,7 +23,7 @@ public class DailyBriefingScheduler {
     GetDailyBriefingResponse dailyBriefing = dailyBriefingService.createDailyBriefing(
         LocalDateTime.now());
 
-    dailyBriefingResponseRedisTemplate.opsForHash().put("daily-briefing", dailyBriefing.standardTime(), dailyBriefing);
+    redisTemplate.opsForHash().put("daily-briefing", dailyBriefing.standardTime(), dailyBriefing);
     log.info("데일리브리핑 스케쥴러 완료");
   }
 

--- a/src/main/java/com/hyperlink/server/domain/dailyBriefing/application/DailyBriefingService.java
+++ b/src/main/java/com/hyperlink/server/domain/dailyBriefing/application/DailyBriefingService.java
@@ -33,18 +33,18 @@ public class DailyBriefingService {
   private final ContentRepository contentRepository;
   private final CategoryRepository categoryRepository;
   private final DailyBriefingRepositoryCustom dailyBriefingRepositoryCustom;
-  private final RedisTemplate<String, GetDailyBriefingResponse> dailyBriefingResponseRedisTemplate;
+  private final RedisTemplate<String, Object> redisTemplate;
 
   public GetDailyBriefingResponse getDailyBriefingResponse(LocalDateTime now) {
     final long whenResponseIsNullRetryPastStandardTime = 1L;
     String standardTime = now.format(DateTimeFormatter.ofPattern(STANDARD_TIME_PATTERN));
-    GetDailyBriefingResponse getDailyBriefingResponse = (GetDailyBriefingResponse) dailyBriefingResponseRedisTemplate.opsForHash()
+    GetDailyBriefingResponse getDailyBriefingResponse = (GetDailyBriefingResponse) redisTemplate.opsForHash()
         .get("daily-briefing", standardTime);
 
     if (getDailyBriefingResponse == null) {
       String pastStandardTime = now.minusHours(whenResponseIsNullRetryPastStandardTime)
           .format(DateTimeFormatter.ofPattern(STANDARD_TIME_PATTERN));
-      getDailyBriefingResponse = (GetDailyBriefingResponse) dailyBriefingResponseRedisTemplate.opsForHash()
+      getDailyBriefingResponse = (GetDailyBriefingResponse) redisTemplate.opsForHash()
           .get("daily-briefing", pastStandardTime);
     }
     return getDailyBriefingResponse;

--- a/src/main/java/com/hyperlink/server/global/config/RedisConfig.java
+++ b/src/main/java/com/hyperlink/server/global/config/RedisConfig.java
@@ -26,10 +26,11 @@ public class RedisConfig {
   }
 
   @Bean
-  public RedisTemplate<String, GetDailyBriefingResponse> dailyBriefingRedisTemplate() {
-    RedisTemplate<String, GetDailyBriefingResponse> redisTemplate = new RedisTemplate<>();
+  public RedisTemplate<String, Object> redisTemplate() {
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
     redisTemplate.setKeySerializer(new StringRedisSerializer());
-    redisTemplate.setValueSerializer(
+    redisTemplate.setValueSerializer(new StringRedisSerializer());
+    redisTemplate.setHashValueSerializer(
         new Jackson2JsonRedisSerializer<>(GetDailyBriefingResponse.class));
     redisTemplate.setConnectionFactory(redisConnectionFactory());
     return redisTemplate;

--- a/src/main/java/com/hyperlink/server/global/config/RedisConfig.java
+++ b/src/main/java/com/hyperlink/server/global/config/RedisConfig.java
@@ -35,13 +35,4 @@ public class RedisConfig {
     redisTemplate.setConnectionFactory(redisConnectionFactory());
     return redisTemplate;
   }
-
-  @Bean
-  public RedisTemplate<String, String> categoryViewRedisTemplate() {
-    RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
-    redisTemplate.setKeySerializer(new StringRedisSerializer());
-    redisTemplate.setValueSerializer(new StringRedisSerializer());
-    redisTemplate.setConnectionFactory(redisConnectionFactory());
-    return redisTemplate;
-  }
 }

--- a/src/main/java/com/hyperlink/server/global/config/RedisConfig.java
+++ b/src/main/java/com/hyperlink/server/global/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package com.hyperlink.server.global.config;
 
+import com.hyperlink.server.domain.admin.dto.CategoryViewResponses;
 import com.hyperlink.server.domain.dailyBriefing.dto.GetDailyBriefingResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -30,6 +31,15 @@ public class RedisConfig {
     redisTemplate.setKeySerializer(new StringRedisSerializer());
     redisTemplate.setValueSerializer(
         new Jackson2JsonRedisSerializer<>(GetDailyBriefingResponse.class));
+    redisTemplate.setConnectionFactory(redisConnectionFactory());
+    return redisTemplate;
+  }
+
+  @Bean
+  public RedisTemplate<String, String> categoryViewRedisTemplate() {
+    RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(new StringRedisSerializer());
     redisTemplate.setConnectionFactory(redisConnectionFactory());
     return redisTemplate;
   }

--- a/src/test/java/com/hyperlink/server/admin/application/AdminServiceUnitTest.java
+++ b/src/test/java/com/hyperlink/server/admin/application/AdminServiceUnitTest.java
@@ -1,0 +1,89 @@
+package com.hyperlink.server.admin.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.hyperlink.server.domain.admin.application.AdminService;
+import com.hyperlink.server.domain.admin.dto.CategoryViewResponses;
+import com.hyperlink.server.domain.admin.dto.CountingViewByCategoryDto;
+import com.hyperlink.server.domain.category.domain.CategoryRepository;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AdminService Mock 테스트")
+public class AdminServiceUnitTest {
+
+  @Nested
+  @DisplayName("[어드민] 7일간의 날짜별, 카테고리별 조회수 조회 기능은")
+  class CountViewCountsByCategoryAndDate {
+
+    @Mock
+    CategoryRepository categoryRepository;
+
+    @InjectMocks
+    AdminService adminService;
+
+    @AllArgsConstructor
+    class CountingViewByCategoryDtoImpl implements CountingViewByCategoryDto {
+
+      Long categoryId;
+      String categoryName;
+      int viewCount;
+
+      @Override
+      public Long getCategoryId() {
+        return categoryId;
+      }
+
+      @Override
+      public String getCategoryName() {
+        return categoryName;
+      }
+
+      @Override
+      public int getViewCount() {
+        return viewCount;
+      }
+    }
+
+
+    @Nested
+    @DisplayName("[성공]")
+    class Success {
+
+      @Test
+      @DisplayName("기준일을 미포함하여 이전 7일간의 카테고리별 조회수를 조회한다.")
+      public void countPastSevenDaysViewCountsByCategory() throws Exception {
+        CountingViewByCategoryDtoImpl develop = new CountingViewByCategoryDtoImpl(1L, "develop",
+            133);
+        CountingViewByCategoryDtoImpl beauty = new CountingViewByCategoryDtoImpl(2L, "beauty",
+            152);
+        when(categoryRepository.countViewsByCategoryAndDate(any())).thenReturn(
+            List.of(develop, beauty));
+
+        CategoryViewResponses categoryViewResponses = adminService.countViewCountByCategory();
+        assertThat(categoryViewResponses.weeklyViewCounts()).hasSize(7);
+        assertThat(categoryViewResponses.createdDate()).isInstanceOf(String.class);
+        assertThat(categoryViewResponses.weeklyViewCounts().get(0).results()).hasSize(2);
+        assertThat(categoryViewResponses.weeklyViewCounts().get(0).results().get(0)
+            .getCategoryName()).isEqualTo("develop");
+        assertThat(categoryViewResponses.weeklyViewCounts().get(0).results().get(0)
+            .getViewCount()).isEqualTo(133);
+        assertThat(categoryViewResponses.weeklyViewCounts().get(0).results().get(1)
+            .getCategoryName()).isEqualTo("beauty");
+        assertThat(categoryViewResponses.weeklyViewCounts().get(0).results().get(1)
+            .getViewCount()).isEqualTo(152);
+      }
+    }
+  }
+
+}

--- a/src/test/java/com/hyperlink/server/admin/controller/AdminControllerTest.java
+++ b/src/test/java/com/hyperlink/server/admin/controller/AdminControllerTest.java
@@ -1,0 +1,116 @@
+package com.hyperlink.server.admin.controller;
+
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hyperlink.server.AuthSetupForMock;
+import com.hyperlink.server.domain.admin.application.AdminService;
+import com.hyperlink.server.domain.admin.controller.AdminController;
+import com.hyperlink.server.domain.admin.domain.vo.CategoryAndView;
+import com.hyperlink.server.domain.admin.dto.CategoryViewResponse;
+import com.hyperlink.server.domain.admin.dto.CategoryViewResponses;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.HttpHeaders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AdminController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc
+public class AdminControllerTest extends AuthSetupForMock {
+
+  @MockBean
+  AdminService adminService;
+  @Autowired
+  MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp() {
+    authSetup();
+  }
+
+  @Nested
+  @DisplayName("카테고리 별 조회수 조회 API는")
+  class CountViewByCategoryTest {
+
+    @Test
+    @DisplayName("조회일로부터 7일 이전의 카테고리별 조회수를 조회한다.")
+    void countViewsByCategoryAndDate() throws Exception {
+      CategoryAndView develop = new CategoryAndView("develop", 133);
+      CategoryAndView beauty = new CategoryAndView("beauty", 152);
+      CategoryViewResponse categoryViewResponse1 = new CategoryViewResponse(List.of(develop, beauty),
+          "2023-03-03");
+      CategoryViewResponse categoryViewResponse2 = new CategoryViewResponse(List.of(develop, beauty),
+          "2023-03-04");
+      CategoryViewResponse categoryViewResponse3 = new CategoryViewResponse(List.of(develop, beauty),
+          "2023-03-05");
+      CategoryViewResponse categoryViewResponse4 = new CategoryViewResponse(List.of(develop, beauty),
+          "2023-03-06");
+      CategoryViewResponse categoryViewResponse5 = new CategoryViewResponse(List.of(develop, beauty),
+          "2023-03-07");
+      CategoryViewResponse categoryViewResponse6 = new CategoryViewResponse(List.of(develop, beauty),
+          "2023-03-08");
+      CategoryViewResponse categoryViewResponse7 = new CategoryViewResponse(List.of(develop, beauty),
+          "2023-03-09");
+      CategoryViewResponses categoryViewResponses = new CategoryViewResponses(
+          List.of(categoryViewResponse1, categoryViewResponse2, categoryViewResponse3,
+              categoryViewResponse4, categoryViewResponse5, categoryViewResponse6,
+              categoryViewResponse7), "2023-03-10");
+      when(adminService.countViewCountByCategory()).thenReturn(categoryViewResponses);
+      when(adminService.getCategoryView()).thenReturn(Optional.of(categoryViewResponses));
+
+      mockMvc.perform(get("/admin/dashboard/all-category/view")
+              .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
+          )
+          .andExpect(status().isOk())
+          .andDo(print())
+          .andDo(
+              document("AdminController/countViewCountByCategory",
+                  preprocessRequest(prettyPrint()),
+                  preprocessResponse(prettyPrint()),
+                  requestHeaders(
+                      headerWithName("Authorization").description("accessToken")
+                  ),
+                  responseFields(
+                      fieldWithPath("weeklyViewCounts[]").type(JsonFieldType.ARRAY)
+                          .description("7일 간의 조회수 조회 배열"),
+                      fieldWithPath("weeklyViewCounts[].results[]").type(JsonFieldType.ARRAY)
+                          .description("1일 간의 카테고리별 조회수 정보 배열"),
+                      fieldWithPath("weeklyViewCounts[].results[].categoryName").type(
+                          JsonFieldType.STRING).description("카테고리 이름"),
+                      fieldWithPath("weeklyViewCounts[].results[].viewCount").type(
+                          JsonFieldType.NUMBER).description("조회수"),
+                      fieldWithPath("weeklyViewCounts[].date").type(JsonFieldType.STRING)
+                          .description("조회 대상 날짜"),
+                      fieldWithPath("createdDate").type(JsonFieldType.STRING)
+                          .description("데이터 생성 날짜")
+                      )
+              )
+          );
+    }
+  }
+
+}

--- a/src/test/java/com/hyperlink/server/category/domain/CategoryRepositoryTest.java
+++ b/src/test/java/com/hyperlink/server/category/domain/CategoryRepositoryTest.java
@@ -3,8 +3,23 @@ package com.hyperlink.server.category.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.hyperlink.server.domain.admin.dto.CountingViewByCategoryDto;
 import com.hyperlink.server.domain.category.domain.CategoryRepository;
 import com.hyperlink.server.domain.category.domain.entity.Category;
+import com.hyperlink.server.domain.content.application.ContentService;
+import com.hyperlink.server.domain.content.domain.ContentRepository;
+import com.hyperlink.server.domain.content.domain.entity.Content;
+import com.hyperlink.server.domain.creator.domain.CreatorRepository;
+import com.hyperlink.server.domain.creator.domain.entity.Creator;
+import com.hyperlink.server.domain.member.domain.Career;
+import com.hyperlink.server.domain.member.domain.CareerYear;
+import com.hyperlink.server.domain.member.domain.MemberRepository;
+import com.hyperlink.server.domain.member.domain.entity.Member;
+import com.hyperlink.server.domain.memberHistory.domain.MemberHistoryRepository;
+import com.hyperlink.server.domain.memberHistory.domain.entity.MemberHistory;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,6 +34,14 @@ public class CategoryRepositoryTest {
 
   @Autowired
   CategoryRepository categoryRepository;
+  @Autowired
+  ContentRepository contentRepository;
+  @Autowired
+  CreatorRepository creatorRepository;
+  @Autowired
+  MemberRepository memberRepository;
+  @Autowired
+  MemberHistoryRepository memberHistoryRepository;
 
   @Test
   @DisplayName("카테고리를 이름으로 검색할 수 있다.")
@@ -29,5 +52,50 @@ public class CategoryRepositoryTest {
     Optional<Category> categoryOptional = categoryRepository.findByName(beauty.getName());
     assertThat(categoryOptional).isPresent();
     assertThat(categoryOptional.get().getName()).isEqualTo(beauty.getName());
+  }
+
+  @Test
+  @DisplayName("원하는 날짜의 카테고리 별 조회수를 조회할 수 있다.")
+  void countViewCountByCategory() throws InterruptedException {
+    LocalDateTime now = LocalDateTime.now();
+    if(now.getHour() == 23 && now.getMinute() == 59) {
+      Thread.sleep(60000);
+    }
+    LocalDate date = LocalDate.now();
+    Member member = new Member("email", "nickname", Career.DEVELOP, CareerYear.EIGHT,
+        "profileImgUrl");
+    memberRepository.save(member);
+    Category categoryDevelop = new Category("develop");
+    categoryRepository.save(categoryDevelop);
+    Category categoryBeauty = new Category("beauty");
+    categoryRepository.save(categoryBeauty);
+    Category categoryFinance = new Category("finance");
+    categoryRepository.save(categoryFinance);
+
+    Creator creatorDevelop = new Creator("develop크리에이터", "profileImgUrl", "description", categoryDevelop);
+    Creator creatorBeauty = new Creator("beauty크리에이터", "profileImgUrl", "description", categoryBeauty);
+    creatorRepository.save(creatorDevelop);
+    creatorRepository.save(creatorBeauty);
+    Content content1 = contentRepository.save(
+        new Content("제목1", "contentImgUrl", "link1", creatorDevelop, categoryDevelop));
+    Content content2 = contentRepository.save(
+        new Content("제목2", "contentImgUrl", "link1", creatorBeauty, categoryBeauty));
+    Content content3 = contentRepository.save(
+        new Content("제목3", "contentImgUrl", "link1", creatorBeauty, categoryBeauty));
+
+    memberHistoryRepository.save(new MemberHistory(member, content1));
+    memberHistoryRepository.save(new MemberHistory(member, content2));
+    memberHistoryRepository.save(new MemberHistory(member, content3));
+
+    List<CountingViewByCategoryDto> countingViewByCategoryDtos = categoryRepository.countViewsByCategoryAndDate(
+        date.toString());
+
+    assertThat(countingViewByCategoryDtos).hasSize(3);
+    assertThat(countingViewByCategoryDtos.get(0).getCategoryName()).isEqualTo("develop");
+    assertThat(countingViewByCategoryDtos.get(0).getViewCount()).isEqualTo(1);
+    assertThat(countingViewByCategoryDtos.get(1).getCategoryName()).isEqualTo("beauty");
+    assertThat(countingViewByCategoryDtos.get(1).getViewCount()).isEqualTo(2);
+    assertThat(countingViewByCategoryDtos.get(2).getCategoryName()).isEqualTo("finance");
+    assertThat(countingViewByCategoryDtos.get(2).getViewCount()).isEqualTo(0);
   }
 }


### PR DESCRIPTION
### 변경 내용 요약
- 조회일 기준 7일전부터 7일동안의 카테고리별 조회수 통계를 제공합니다.
- Daily-Briefing과 동일하게 Redis를 사용하여 캐싱하였습니다.

### 작업한 내용
- CategoryView 조회 기능 구현(어드민)
- CategoryView 테스트 코드 작성

close #210 