### PR TITLE
[#251] 검색 API 전체 사이즈 에러 수정

### DIFF
--- a/src/main/java/com/hyperlink/server/domain/content/application/ContentService.java
+++ b/src/main/java/com/hyperlink/server/domain/content/application/ContentService.java
@@ -63,14 +63,13 @@ public class ContentService {
 
   public SearchResponse search(Long memberId, String keyword, Pageable pageable) {
     List<String> keywords = splitSearchKeywords(keyword);
-    Slice<Content> searchResultContents = contentRepositoryCustom.searchByTitleContainingOrderByLatest(
-        keywords,
-        pageable);
+    Page<Content> searchResultContents = contentRepositoryCustom.searchByTitleContainingOrderByLatest(
+        keywords, pageable);
 
     GetContentsCommonResponse contentResponses = contentDtoFactoryService.createContentResponses(
         memberId, searchResultContents.getContent(), searchResultContents.hasNext());
     return new SearchResponse(contentResponses, keyword,
-        searchResultContents.getNumberOfElements());
+        (int) searchResultContents.getTotalElements());
   }
 
   private List<String> splitSearchKeywords(String keyword) {

--- a/src/main/java/com/hyperlink/server/domain/content/infrastructure/ContentRepositoryCustom.java
+++ b/src/main/java/com/hyperlink/server/domain/content/infrastructure/ContentRepositoryCustom.java
@@ -10,6 +10,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -27,7 +28,7 @@ public class ContentRepositoryCustom {
 
   private final JPAQueryFactory queryFactory;
 
-  public Slice<Content> searchByTitleContainingOrderByLatest(List<String> keywords,
+  public Page<Content> searchByTitleContainingOrderByLatest(List<String> keywords,
       Pageable pageable) {
     BooleanBuilder builder = new BooleanBuilder();
     for (String keyword : keywords) {


### PR DESCRIPTION
### 변경 내용 요약
- 검색 API 전체 사이즈 에러 수정

### 작업한 내용
- 검색 API 응답값 중에 전체 검색 결과 사이즈가 request size로 잘못 응답되는 오류가 있어서 수정했어요!
- Slice interface에는 totalElements 필드가 없어서 Page interface로 변경했어요

### 기타 사항
- hotfix인 관계로 머지 먼저 할게요! 😵

close #251 
