### PR TITLE
[#256] 테스트 코드 오류 해결

### DIFF
--- a/src/main/java/com/hyperlink/server/domain/admin/controller/AdminScheduler.java
+++ b/src/main/java/com/hyperlink/server/domain/admin/controller/AdminScheduler.java
@@ -20,7 +20,7 @@ public class AdminScheduler {
   private final RedisTemplate<String, Object> redisTemplate;
   private static final String CATEGORY_VIEW = "category-view";
 
-  @Scheduled(cron = "0 25 20 * * *", zone = "Asia/Seoul")
+  @Scheduled(cron = "0 5 0 * * *", zone = "Asia/Seoul")
   void createCategoryViewDashboardData() {
     log.info("[Admin] 카테고리 별 조회수 수집");
     CategoryViewResponses categoryViewResponses = adminService.countViewCountByCategory();

--- a/src/main/java/com/hyperlink/server/global/filter/AuthenticationFilter.java
+++ b/src/main/java/com/hyperlink/server/global/filter/AuthenticationFilter.java
@@ -26,7 +26,7 @@ public class AuthenticationFilter implements Filter {
   private static final String[] whitelist = {"/", "/members/logout", "/members/login",
       "/members/signup", "/profile", "/actuator/health", "/members/oauth/code/google",
       "/members/access-token", "/contents/*/view", "/daily-briefing", "/contents/all",
-      "/contents", "/creators", "/creators/*", "/creators/recommend", "/test/scheduler-trigger/recommend"};
+      "/contents", "/creators", "/creators/*", "/creators/recommend", "/test/scheduler-trigger/recommend", "/save"};
 
 
   private final AuthTokenExtractor authTokenExtractor;

--- a/src/test/java/com/hyperlink/server/admin/controller/AdminControllerTest.java
+++ b/src/test/java/com/hyperlink/server/admin/controller/AdminControllerTest.java
@@ -19,12 +19,14 @@ import com.hyperlink.server.domain.admin.controller.AdminController;
 import com.hyperlink.server.domain.admin.domain.vo.CategoryAndView;
 import com.hyperlink.server.domain.admin.dto.CategoryViewResponse;
 import com.hyperlink.server.domain.admin.dto.CategoryViewResponses;
+import com.hyperlink.server.global.config.BatchJobConfig;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -43,6 +45,11 @@ public class AdminControllerTest extends AdminAuthSetupForMock {
 
   @MockBean
   AdminService adminService;
+  @MockBean
+  JobLauncher jobLauncher;
+  @MockBean
+  BatchJobConfig batchJobConfig;
+
   @Autowired
   MockMvc mockMvc;
 

--- a/src/test/java/com/hyperlink/server/category/domain/CategoryRepositoryTest.java
+++ b/src/test/java/com/hyperlink/server/category/domain/CategoryRepositoryTest.java
@@ -27,8 +27,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
-@DataJpaTest
+@SpringBootTest
+@Transactional
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 public class CategoryRepositoryTest {
 

--- a/src/test/java/com/hyperlink/server/content/application/ContentServiceIntegrationTest.java
+++ b/src/test/java/com/hyperlink/server/content/application/ContentServiceIntegrationTest.java
@@ -455,7 +455,7 @@ public class ContentServiceIntegrationTest {
         @DisplayName("최신순으로 조회할 수 있다.")
         void retrieveRecent() {
           GetContentsCommonResponse getContentsCommonResponse = contentService.retrieveTrendContents(
-              null, "개발", "recent", PageRequest.of(0, 10));
+              null, "개발10", "recent", PageRequest.of(0, 10));
 
           List<ContentResponse> contents = getContentsCommonResponse.contents();
           assertThat(contents).hasSize(3);
@@ -470,7 +470,7 @@ public class ContentServiceIntegrationTest {
           contentService.addView(member.getId(), content3.getId());
 
           GetContentsCommonResponse getContentsCommonResponse = contentService.retrieveTrendContents(
-              null, "개발", "popular", PageRequest.of(0, 10));
+              null, "개발10", "popular", PageRequest.of(0, 10));
 
           List<ContentResponse> contents = getContentsCommonResponse.contents();
           assertThat(contents).hasSize(3);

--- a/src/test/java/com/hyperlink/server/content/domain/ContentRepositoryTest.java
+++ b/src/test/java/com/hyperlink/server/content/domain/ContentRepositoryTest.java
@@ -15,8 +15,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
-@DataJpaTest
+@SpringBootTest
+@Transactional
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 class ContentRepositoryTest {
 

--- a/src/test/java/com/hyperlink/server/creator/controller/CreatorControllerTest.java
+++ b/src/test/java/com/hyperlink/server/creator/controller/CreatorControllerTest.java
@@ -26,6 +26,7 @@ import com.hyperlink.server.AdminAuthSetupForMock;
 import com.hyperlink.server.domain.category.domain.entity.Category;
 import com.hyperlink.server.domain.creator.application.CreatorService;
 import com.hyperlink.server.domain.creator.controller.CreatorController;
+import com.hyperlink.server.domain.creator.domain.CreatorRecommendService;
 import com.hyperlink.server.domain.creator.domain.entity.Creator;
 import com.hyperlink.server.domain.creator.dto.CreatorAdminResponse;
 import com.hyperlink.server.domain.creator.dto.CreatorAdminResponses;
@@ -65,6 +66,8 @@ public class CreatorControllerTest extends AdminAuthSetupForMock {
 
   @MockBean
   CreatorService creatorService;
+  @MockBean
+  CreatorRecommendService creatorRecommendService;
   @Autowired
   MockMvc mockMvc;
   @Autowired

--- a/src/test/java/com/hyperlink/server/creator/domain/CreatorRepositoryTest.java
+++ b/src/test/java/com/hyperlink/server/creator/domain/CreatorRepositoryTest.java
@@ -27,11 +27,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
+import org.springframework.transaction.annotation.Transactional;
 
-@DataJpaTest
+@SpringBootTest
+@Transactional
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 public class CreatorRepositoryTest {
 

--- a/src/test/java/com/hyperlink/server/dailyBriefing/controller/DailyBriefingControllerTest.java
+++ b/src/test/java/com/hyperlink/server/dailyBriefing/controller/DailyBriefingControllerTest.java
@@ -77,7 +77,7 @@ public class DailyBriefingControllerTest extends AuthSetupForMock {
       @Test
       @DisplayName("데일리브리핑 조회에 성공하고 OK와 데일리브리핑을 응답한다")
       void getDailyBriefing() throws Exception {
-        doReturn(getDailyBriefingResponse).when(dailyBriefingService).createDailyBriefing(any());
+        doReturn(getDailyBriefingResponse).when(dailyBriefingService).getDailyBriefingResponse(any());
 
         mockMvc.perform(
                 get("/daily-briefing")


### PR DESCRIPTION
### 변경 내용 요약
- 테스트 코드가 동작하지 않던 문제를 해결했습니다.


### 작업한 내용
- Spring Batch가 들어오면서 DataJpaTest가 붙은 테스트들은 전부 실패함.
- 이유는, Spring Batch가 트랜잭션을 사용할 때 DataJpaTest의 트랜잭션을 무시하게 만들어서 save 명령이 나가지 않는 문제 발생
- DataJpaTest 어노테이션을 SpringBootTest 어노테이션으로 변경하여 해결

- DailyBriefingControllerTest에서 Service 모킹 시 실제 컨트롤러에서 사용하는 getDailyBriefing 메서드를 모킹하지 않고 createDailyBriefing 메서드를 모킹중이어서 에러 발생했음
- 이를 해결함

close #256
