### PR TITLE
[#268] 추천 크리에이터 조회 API 비회원 요청 금지

### DIFF
--- a/src/main/java/com/hyperlink/server/domain/creator/controller/CreatorController.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/controller/CreatorController.java
@@ -97,7 +97,7 @@ public class CreatorController {
   @ResponseStatus(HttpStatus.OK)
   public GetCreatorRecommendResponses getCreatorRecommendResponse(
       @LoginMemberId Optional<Long> optionalMemberId) {
-    Long memberId = optionalMemberId.orElse(null);
+    Long memberId = optionalMemberId.orElseThrow(TokenNotExistsException::new);
     return creatorRecommendService.getRecommendCreators(memberId);
   }
 

--- a/src/main/java/com/hyperlink/server/domain/creator/domain/CreatorRecommendService.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/domain/CreatorRecommendService.java
@@ -41,13 +41,6 @@ public class CreatorRecommendService {
   private final RedisTemplate<String, Object> redisTemplate;
 
   public GetCreatorRecommendResponses getRecommendCreators(Long memberId) {
-    if (memberId == null) {
-      List<Long> allCreatorIds = creatorRepository.findAllIds();
-      List<GetCreatorRecommendResponse> randomCreators = extractRandomCreators(
-          allCreatorIds, allCreatorIds.size());
-      return new GetCreatorRecommendResponses(randomCreators);
-    }
-
     Set<Object> recommendedPoolCreatorIdsSet = redisTemplate.opsForZSet()
         .reverseRange(memberId.toString(), FIRST_INDEX, LAST_INDEX);
     List<Long> recommendedPoolCreatorIds = Objects.requireNonNull(recommendedPoolCreatorIdsSet)

--- a/src/main/java/com/hyperlink/server/global/filter/AuthenticationFilter.java
+++ b/src/main/java/com/hyperlink/server/global/filter/AuthenticationFilter.java
@@ -26,7 +26,7 @@ public class AuthenticationFilter implements Filter {
   private static final String[] whitelist = {"/", "/members/logout", "/members/login",
       "/members/signup", "/profile", "/actuator/health", "/members/oauth/code/google",
       "/members/access-token", "/contents/*/view", "/daily-briefing", "/contents/all",
-      "/contents", "/creators", "/creators/*", "/creators/recommend", "/test/scheduler-trigger/recommend", "/save"};
+      "/contents", "/creators", "/creators/*", "/test/scheduler-trigger/recommend", "/save"};
 
 
   private final AuthTokenExtractor authTokenExtractor;


### PR DESCRIPTION
### 변경 내용 요약
- 추천 크리에이터 조회 API 비회원 요청 금지

### 작업한 내용
- 추천 크리에이터 조회 API 비회원은 요청하지 못하도록 금지했어요!

close #268
