### PR TITLE
[#309] 추천 크리에이터 조회 API 응답 중복값 제거

### DIFF
--- a/src/main/java/com/hyperlink/server/domain/creator/domain/CreatorRecommendService.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/domain/CreatorRecommendService.java
@@ -15,6 +15,7 @@ import com.hyperlink.server.domain.notRecommendCreator.domain.NotRecommendCreato
 import com.hyperlink.server.domain.subscription.domain.SubscriptionRepository;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -58,9 +59,14 @@ public class CreatorRecommendService {
     List<GetCreatorRecommendResponse> getCreatorRecommendResponses = new ArrayList<>();
 
     Random random = new Random();
-    for (int i = 0; i < 4; i++) {
+    Set<Integer> randomIndexes = new HashSet<>();
+    while (randomIndexes.size() < 4) {
       int randomIndex = random.nextInt(randomIntRange);
-      Long creatorId = recommendedPoolCreatorIds.get(randomIndex);
+      randomIndexes.add(randomIndex);
+    }
+
+    randomIndexes.forEach(randomCreatorId -> {
+      Long creatorId = recommendedPoolCreatorIds.get(randomCreatorId);
 
       CreatorAndSubscriptionCountMapper creatorAndSubscriptionCount = creatorRepository.findCreatorAndSubscriptionCount(
           creatorId);
@@ -70,7 +76,7 @@ public class CreatorRecommendService {
           creatorAndSubscriptionCount.getDescription(),
           creatorAndSubscriptionCount.getSubscriberAmount());
       getCreatorRecommendResponses.add(getCreatorRecommendResponse);
-    }
+    });
 
     return getCreatorRecommendResponses;
   }


### PR DESCRIPTION
### 변경 내용 요약
- 추천 크리에이터 조회 API 응답 중복값 제거

### 작업한 내용
- 랜덤으로 추출되던 id 값이 중복되던 오류가 있어서 수정했어요

### 기타사항
QA!!!!!!!! 😵

close #309 
