### PR TITLE
[#319] [Admin] 크리에이터 조회 페이지 프로필 이미지 링크 전송하도록 변경

### DIFF
--- a/src/main/java/com/hyperlink/server/domain/creator/dto/CreatorAdminResponse.java
+++ b/src/main/java/com/hyperlink/server/domain/creator/dto/CreatorAdminResponse.java
@@ -2,9 +2,10 @@ package com.hyperlink.server.domain.creator.dto;
 
 import com.hyperlink.server.domain.creator.domain.entity.Creator;
 
-public record CreatorAdminResponse(Long creatorId, String name, String description, String categoryName) {
+public record CreatorAdminResponse(Long creatorId, String name, String description, String categoryName,
+                                   String profileImgUrl) {
   public static CreatorAdminResponse from(Creator creator) {
     return new CreatorAdminResponse(creator.getId(), creator.getName(), creator.getDescription(),
-        creator.getCategoryName());
+        creator.getCategoryName(), creator.getProfileImgUrl());
   }
 }

--- a/src/test/java/com/hyperlink/server/creator/controller/CreatorControllerTest.java
+++ b/src/test/java/com/hyperlink/server/creator/controller/CreatorControllerTest.java
@@ -466,13 +466,13 @@ public class CreatorControllerTest extends AdminAuthSetupForMock {
         String page = "0";
         String size = "10";
         CreatorAdminResponse creatorAdminResponse1 = new CreatorAdminResponse(1L, "네이버 D2",
-            "네이버 D2 블로그", "develop");
+            "네이버 D2 블로그", "develop", "https://img.naver.com/blogs");
         CreatorAdminResponse creatorAdminResponse2 = new CreatorAdminResponse(2L, "카카오 디벨로퍼스",
-            "카카오 디벨로퍼스 블로그", "develop");
+            "카카오 디벨로퍼스 블로그", "develop", "https://img.kakao.com/blogs");
         CreatorAdminResponse creatorAdminResponse3 = new CreatorAdminResponse(3L, "토스 테크",
-            "토스 테크 블로그", "develop");
+            "토스 테크 블로그", "develop", "https://img.toss.com/blogs");
         CreatorAdminResponse creatorAdminResponse4 = new CreatorAdminResponse(4L, "VOGUE",
-            "VOGUE 패션 메거진", "beauty");
+            "VOGUE 패션 메거진", "beauty", "https://img.vogue.com/blogs");
         CreatorAdminResponses creatorAdminResponses = new CreatorAdminResponses(
             List.of(creatorAdminResponse1, creatorAdminResponse2, creatorAdminResponse3,
                 creatorAdminResponse4), 1, 1);
@@ -501,69 +501,8 @@ public class CreatorControllerTest extends AdminAuthSetupForMock {
                         .description("크리에이터 소개글"),
                     fieldWithPath("creators[].categoryName").type(JsonFieldType.STRING)
                         .description("크리에이터 카테고리 이름"),
-                    fieldWithPath("currentPage").type(JsonFieldType.NUMBER)
-                        .description("현재 조회중인 페이지 번호"),
-                    fieldWithPath("totalPage").type(JsonFieldType.NUMBER).description("전체 페이지 번호")
-                )
-            ));
-      }
-    }
-  }
-
-  @Nested
-  @DisplayName("[Admin] 크리에이터 전체 조회 API는")
-  class CreatorRetrievalAdminTestV1 {
-
-    @Nested
-    @DisplayName("[성공]")
-    class Success {
-
-      @BeforeEach
-      void setUp() {
-        authSetup();
-      }
-
-      @Test
-      @DisplayName("전체 크리에이터 정보를 조회한다.")
-      void retrieveCreatorForAdminReturnsOK() throws Exception {
-        String page = "0";
-        String size = "10";
-        CreatorAdminResponse creatorAdminResponse1 = new CreatorAdminResponse(1L, "네이버 D2",
-            "네이버 D2 블로그", "develop");
-        CreatorAdminResponse creatorAdminResponse2 = new CreatorAdminResponse(2L, "카카오 디벨로퍼스",
-            "카카오 디벨로퍼스 블로그", "develop");
-        CreatorAdminResponse creatorAdminResponse3 = new CreatorAdminResponse(3L, "토스 테크",
-            "토스 테크 블로그", "develop");
-        CreatorAdminResponse creatorAdminResponse4 = new CreatorAdminResponse(4L, "VOGUE",
-            "VOGUE 패션 메거진", "beauty");
-        CreatorAdminResponses creatorAdminResponses = new CreatorAdminResponses(
-            List.of(creatorAdminResponse1, creatorAdminResponse2, creatorAdminResponse3,
-                creatorAdminResponse4), 0, 1);
-
-        when(creatorService.retrieveCreatorsForAdmin(any())).thenReturn(creatorAdminResponses);
-
-        mockMvc.perform(get("/admin/creators")
-                .header(HttpHeaders.AUTHORIZATION, authorizationHeader)
-                .param("page", page)
-                .param("size", size))
-            .andExpect(status().isOk())
-            .andDo(print())
-            .andDo(document("CreatorControllerTest/retrieveCreatorsAdmin",
-                preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()),
-                requestHeaders(
-                    headerWithName("Authorization").description("accessToken")
-                ),
-                responseFields(
-                    fieldWithPath("creators[]").type(JsonFieldType.ARRAY).description("크리에이터 목록"),
-                    fieldWithPath("creators[].creatorId").type(JsonFieldType.NUMBER)
-                        .description("크리에이터 id"),
-                    fieldWithPath("creators[].name").type(JsonFieldType.STRING)
-                        .description("크리에이터 이름"),
-                    fieldWithPath("creators[].description").type(JsonFieldType.STRING)
-                        .description("크리에이터 소개글"),
-                    fieldWithPath("creators[].categoryName").type(JsonFieldType.STRING)
-                        .description("크리에이터 카테고리 이름"),
+                    fieldWithPath("creators[].profileImgUrl").type(JsonFieldType.STRING)
+                        .description("크리에이터 프로필 이미지"),
                     fieldWithPath("currentPage").type(JsonFieldType.NUMBER)
                         .description("현재 조회중인 페이지 번호"),
                     fieldWithPath("totalPage").type(JsonFieldType.NUMBER).description("전체 페이지 번호")
@@ -600,7 +539,8 @@ public class CreatorControllerTest extends AdminAuthSetupForMock {
         GetCreatorRecommendResponses getCreatorRecommendResponses = new GetCreatorRecommendResponses(
             creators);
 
-        when(creatorRecommendService.getRecommendCreators(any())).thenReturn(getCreatorRecommendResponses);
+        when(creatorRecommendService.getRecommendCreators(any())).thenReturn(
+            getCreatorRecommendResponses);
 
         mockMvc.perform(get("/creators/recommend")
                 .header(HttpHeaders.AUTHORIZATION, authorizationHeader))
@@ -630,4 +570,4 @@ public class CreatorControllerTest extends AdminAuthSetupForMock {
     }
   }
 
-      }
+}


### PR DESCRIPTION
### 변경 내용 요약
- 어드민 페이지 크리에이터 전체 조회 필드 추가
- 컨트롤러 테스트 코드 변경

close #319
