### PR TITLE
[#262] 검색 응답 페이지 정렬 기준 변경

### DIFF
--- a/src/test/java/com/hyperlink/server/content/domain/ContentRepositoryTest.java
+++ b/src/test/java/com/hyperlink/server/content/domain/ContentRepositoryTest.java
@@ -7,14 +7,17 @@ import com.hyperlink.server.domain.category.domain.entity.Category;
 import com.hyperlink.server.domain.content.domain.ContentRepository;
 import com.hyperlink.server.domain.content.domain.entity.Content;
 import com.hyperlink.server.domain.content.exception.ContentNotFoundException;
+import com.hyperlink.server.domain.content.infrastructure.ContentRepositoryCustom;
 import com.hyperlink.server.domain.creator.domain.CreatorRepository;
 import com.hyperlink.server.domain.creator.domain.entity.Creator;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = Replace.NONE)
@@ -26,6 +29,8 @@ class ContentRepositoryTest {
   CreatorRepository creatorRepository;
   @Autowired
   CategoryRepository categoryRepository;
+  @Autowired
+  ContentRepositoryCustom contentRepositoryCustom;
 
   @Test
   @DisplayName("조회수 update 메소드를 실행하면 조회수가 +1 된다")
@@ -44,5 +49,16 @@ class ContentRepositoryTest {
         .orElseThrow(ContentNotFoundException::new);
 
     assertThat(findContent.getViewCount()).isEqualTo(beforeInquiry + 1);
+  }
+
+  @Test
+  void fsfd() {
+    List<String> adf = List.of("코딩", "당근", "효");
+    List<Content> content = contentRepositoryCustom.searchByTitleContainingOrderByLatest(adf,
+        PageRequest.of(0, 100)).getContent();
+
+    for (Content content1 : content) {
+      System.out.println(content1.toString());
+    }
   }
 }


### PR DESCRIPTION
### 변경 내용 요약
- 검색 응답 페이지 정렬 기준 변경

### 작업한 내용
- 기존에 최신순 내림차순으로만 정렬하던 기준을 최신순, 히스토리 유저 클릭 패턴 분석 + 조회수로 변경했어요!

close #262 
